### PR TITLE
AB#118352 remove school and trust imfo fields

### DIFF
--- a/app/views/sprint-48/overview/summary1-involuntary.html
+++ b/app/views/sprint-48/overview/summary1-involuntary.html
@@ -7,7 +7,7 @@
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-l">St. Wilfrid's Primary School</span>
+    <span class="govuk-caption-l">Cheltenham Spa Primary School</span>
     <h1 class="govuk-heading-l">
     Confirm school and trust information and project dates</h1>
     <p>This information is pre-populated from TRAMS.</p>
@@ -56,43 +56,6 @@
         <dd class="govuk-summary-list__actions">
         </dd>
       </div>
-
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key govuk-!-width-two-thirds">
-          Recommendation
-        </dt>
-        <dd class="govuk-summary-list__value">
-          {% if data['recomendation']%}
-            {{data['recomendation']}}
-            {% else %} 
-            <span class="empty">Empty</span>
-          {% endif %}
-
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <a class="govuk-link" href="recommendation">
-            Change<span class="govuk-visually-hidden">recommendation</span>
-          </a>
-        </dd>
-      </div>
-
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Is an academy order (AO) required?
-        </dt>
-        <dd class="govuk-summary-list__value">
-          {% if data['aorequired']%}
-          {{data['aorequired']}}
-          {% else %} 
-          <span class="empty">Empty</span>
-        {% endif %}
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <a class="govuk-link" href="aorequired.html">
-            Change<span class="govuk-visually-hidden">academy order required</span>
-          </a>
-        </dd>
-</div>
 
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">


### PR DESCRIPTION
# Context

'Recommendation' and 'Is an Academy Order (AO) required? fields removed.

Both are n/a for involuntary conversions.

# DevOps ticket:

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/118352

# Changes proposed in this pull request

'Recommendation' and 'Is an Academy Order (AO) required? fields removed.

# Checklist

- Rebased master
- Cleaned commit history
- Tested by running locally