### PR TITLE
AB#118588 Key stage 4 status row added for provisional and revised data

### DIFF
--- a/app/views/sprint-48/key-stage/key-stage-4-performance-comments-involuntary.html
+++ b/app/views/sprint-48/key-stage/key-stage-4-performance-comments-involuntary.html
@@ -25,12 +25,24 @@
   <h1 class="govuk-heading-l">Key stage 4 performance tables</h1>
   <p class="govuk-body">This information comes from TRAMS and you can <a href="#additional_info">add additional information</a> if you need to. These performance tables and additional information will go into your project template.</p>
   
-  <p class="govuk-body-s">TRAMS last updated on: 23 March 2021<br>
+  <p class="govuk-body">TRAMS last updated on: 23 March 2021<br>
     <a href="https://www.compare-school-performance.service.gov.uk/school/<URN>" class="govuk-link" rel="noreferrer noopener" target="_blank">Source of data: Find and compare school performance (opens in new tab)</a>
-  </p><br>
+  </p>
+
+  <div class="govuk-inset-text">
+    There is no 2019 to 2020 key stage data because of the pandemic. 2020 to 2021 data is limited. 2021 to 2022 data is provisional.
+  </div>
+
   </div></div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full govuk-!-margin-bottom-3">
+
+       
+
+      
+
+
+
         <h2 class="govuk-heading-l">
             Attainment 8
         </h2>
@@ -47,28 +59,44 @@
       
         <th scope="col" class="govuk-table__header"></th>
       
-        <th scope="col" class="govuk-table__header">2016<br>
-          <strong class="govuk-tag govuk-tag--grey">
-          Provisional
-          </strong>
+        <th scope="col" class="govuk-table__header">2021 to 2022
         </th>
       
-        <th scope="col" class="govuk-table__header">2017<br>
-          <strong class="govuk-tag govuk-tag--green">
-          Revised
-          </strong>
+        <th scope="col" class="govuk-table__header">2020 to 2021
         </th>
       
-        <th scope="col" class="govuk-table__header">2018<br>
-          <strong class="govuk-tag govuk-tag--green">
-          Revised
-          </strong>
+        <th scope="col" class="govuk-table__header">2018 to 2019
         </th>
       
       </tr>
       </thead>
       
       <tbody class="govuk-table__body">
+
+        <tr class="govuk-table__row">
+          
+          <th scope="row" class="govuk-table__header">Status</th>
+          
+          <td class="govuk-table__cell"> 
+            <strong class="govuk-tag govuk-tag--grey">
+            Provisional
+            </strong>
+          </td>
+          
+          <td class="govuk-table__cell">
+            <strong class="govuk-tag govuk-tag--green">
+            Revised
+            </strong>
+          </td>
+          
+          <td class="govuk-table__cell">
+            <strong class="govuk-tag govuk-tag--green">
+            Revised
+              </strong>
+          </td>
+          
+        </tr>
+
       
         
           <tr class="govuk-table__row">
@@ -100,6 +128,10 @@
           </tr>
         
       
+
+          
+
+
         
           <tr class="govuk-table__row">
           
@@ -172,28 +204,44 @@
       
         <th scope="col" class="govuk-table__header"></th>
       
-        <th scope="col" class="govuk-table__header">2016<br>
-          <strong class="govuk-tag govuk-tag--grey">
-          Provisional
-          </strong>
+        <th scope="col" class="govuk-table__header">2021 to 2022
         </th>
       
-        <th scope="col" class="govuk-table__header">2017<br>
-          <strong class="govuk-tag govuk-tag--green">
-          Revised
-          </strong>
+        <th scope="col" class="govuk-table__header">2020 to 2021
         </th>
       
-        <th scope="col" class="govuk-table__header">2018<br>
-          <strong class="govuk-tag govuk-tag--green">
-          Revised
-          </strong>
+        <th scope="col" class="govuk-table__header">2018 to 2019
         </th>
       
       </tr>
       </thead>
       
       <tbody class="govuk-table__body">
+
+        <tr class="govuk-table__row">
+          
+          <th scope="row" class="govuk-table__header">Status</th>
+          
+          <td class="govuk-table__cell"> 
+            <strong class="govuk-tag govuk-tag--grey">
+            Provisional
+            </strong>
+          </td>
+          
+          <td class="govuk-table__cell">
+            <strong class="govuk-tag govuk-tag--green">
+            Revised
+            </strong>
+          </td>
+          
+          <td class="govuk-table__cell">
+            <strong class="govuk-tag govuk-tag--green">
+            Revised
+              </strong>
+          </td>
+          
+        </tr>
+
       
         
           <tr class="govuk-table__row">
@@ -299,28 +347,44 @@
       
         <th scope="col" class="govuk-table__header"></th>
       
-        <th scope="col" class="govuk-table__header">2016<br>
-          <strong class="govuk-tag govuk-tag--grey">
-          Provisional
-          </strong>
+        <th scope="col" class="govuk-table__header">2021 to 2022
         </th>
       
-        <th scope="col" class="govuk-table__header">2017<br>
-          <strong class="govuk-tag govuk-tag--green">
-          Revised
-          </strong>
+        <th scope="col" class="govuk-table__header">2020 to 2021
         </th>
       
-        <th scope="col" class="govuk-table__header">2018<br>
-          <strong class="govuk-tag govuk-tag--green">
-          Revised
-          </strong>
+        <th scope="col" class="govuk-table__header">2018 to 2019
         </th>
       
       </tr>
       </thead>
       
       <tbody class="govuk-table__body">
+
+        <tr class="govuk-table__row">
+          
+          <th scope="row" class="govuk-table__header">Status</th>
+          
+          <td class="govuk-table__cell"> 
+            <strong class="govuk-tag govuk-tag--grey">
+            Provisional
+            </strong>
+          </td>
+          
+          <td class="govuk-table__cell">
+            <strong class="govuk-tag govuk-tag--green">
+            Revised
+            </strong>
+          </td>
+          
+          <td class="govuk-table__cell">
+            <strong class="govuk-tag govuk-tag--green">
+            Revised
+              </strong>
+          </td>
+          
+        </tr>
+
       
         
           <tr class="govuk-table__row">
@@ -426,28 +490,44 @@
       
         <th scope="col" class="govuk-table__header"></th>
       
-        <th scope="col" class="govuk-table__header">2016<br>
-          <strong class="govuk-tag govuk-tag--grey">
-          Provisional
-          </strong>
+        <th scope="col" class="govuk-table__header">2021 to 2022
         </th>
       
-        <th scope="col" class="govuk-table__header">2017<br>
-          <strong class="govuk-tag govuk-tag--green">
-          Revised
-          </strong>
+        <th scope="col" class="govuk-table__header">2020 to 2021
         </th>
       
-        <th scope="col" class="govuk-table__header">2018<br>
-          <strong class="govuk-tag govuk-tag--green">
-          Revised
-          </strong>
+        <th scope="col" class="govuk-table__header">2018 to 2019
         </th>
       
       </tr>
       </thead>
       
       <tbody class="govuk-table__body">
+
+        <tr class="govuk-table__row">
+          
+          <th scope="row" class="govuk-table__header">Status</th>
+          
+          <td class="govuk-table__cell"> 
+            <strong class="govuk-tag govuk-tag--grey">
+            Provisional
+            </strong>
+          </td>
+          
+          <td class="govuk-table__cell">
+            <strong class="govuk-tag govuk-tag--green">
+            Revised
+            </strong>
+          </td>
+          
+          <td class="govuk-table__cell">
+            <strong class="govuk-tag govuk-tag--green">
+            Revised
+              </strong>
+          </td>
+          
+        </tr>
+
       
         
           <tr class="govuk-table__row">
@@ -560,28 +640,44 @@
       
         <th scope="col" class="govuk-table__header"></th>
       
-        <th scope="col" class="govuk-table__header">2016<br>
-          <strong class="govuk-tag govuk-tag--grey">
-          Provisional
-          </strong>
+        <th scope="col" class="govuk-table__header">2021 to 2022
         </th>
       
-        <th scope="col" class="govuk-table__header">2017<br>
-          <strong class="govuk-tag govuk-tag--green">
-          Revised
-          </strong>
+        <th scope="col" class="govuk-table__header">2020 to 2021
         </th>
       
-        <th scope="col" class="govuk-table__header">2018<br>
-          <strong class="govuk-tag govuk-tag--green">
-          Revised
-          </strong>
+        <th scope="col" class="govuk-table__header">2018 to 2019
         </th>
       
       </tr>
       </thead>
       
       <tbody class="govuk-table__body">
+
+        <tr class="govuk-table__row">
+          
+          <th scope="row" class="govuk-table__header">Status</th>
+          
+          <td class="govuk-table__cell"> 
+            <strong class="govuk-tag govuk-tag--grey">
+            Provisional
+            </strong>
+          </td>
+          
+          <td class="govuk-table__cell">
+            <strong class="govuk-tag govuk-tag--green">
+            Revised
+            </strong>
+          </td>
+          
+          <td class="govuk-table__cell">
+            <strong class="govuk-tag govuk-tag--green">
+            Revised
+              </strong>
+          </td>
+          
+        </tr>
+
       
         
           <tr class="govuk-table__row">
@@ -687,28 +783,44 @@
       
         <th scope="col" class="govuk-table__header"></th>
       
-        <th scope="col" class="govuk-table__header">2016<br>
-          <strong class="govuk-tag govuk-tag--grey">
-          Provisional
-          </strong>
+        <th scope="col" class="govuk-table__header">2021 to 2022
         </th>
       
-        <th scope="col" class="govuk-table__header">2017<br>
-          <strong class="govuk-tag govuk-tag--green">
-          Revised
-          </strong>
+        <th scope="col" class="govuk-table__header">2020 to 2021
         </th>
       
-        <th scope="col" class="govuk-table__header">2018<br>
-          <strong class="govuk-tag govuk-tag--green">
-          Revised
-          </strong>
+        <th scope="col" class="govuk-table__header">2018 to 2019
         </th>
       
       </tr>
       </thead>
       
       <tbody class="govuk-table__body">
+
+        <tr class="govuk-table__row">
+          
+          <th scope="row" class="govuk-table__header">Status</th>
+          
+          <td class="govuk-table__cell"> 
+            <strong class="govuk-tag govuk-tag--grey">
+            Provisional
+            </strong>
+          </td>
+          
+          <td class="govuk-table__cell">
+            <strong class="govuk-tag govuk-tag--green">
+            Revised
+            </strong>
+          </td>
+          
+          <td class="govuk-table__cell">
+            <strong class="govuk-tag govuk-tag--green">
+            Revised
+              </strong>
+          </td>
+          
+        </tr>
+
       
         
           <tr class="govuk-table__row">
@@ -903,28 +1015,44 @@
         
           <th scope="col" class="govuk-table__header"></th>
         
-          <th scope="col" class="govuk-table__header">2016<br>
-            <strong class="govuk-tag govuk-tag--grey">
-            Provisional
-            </strong>
+          <th scope="col" class="govuk-table__header">2021 to 2022
           </th>
         
-          <th scope="col" class="govuk-table__header">2017<br>
-            <strong class="govuk-tag govuk-tag--green">
-            Revised
-            </strong>
+          <th scope="col" class="govuk-table__header">2020 to 2021
           </th>
         
-          <th scope="col" class="govuk-table__header">2018<br>
-            <strong class="govuk-tag govuk-tag--green">
-            Revised
-            </strong>
+          <th scope="col" class="govuk-table__header">2018 to 2019
           </th>
         
         </tr>
         </thead>
         
         <tbody class="govuk-table__body">
+
+          <tr class="govuk-table__row">
+          
+            <th scope="row" class="govuk-table__header">Status</th>
+            
+            <td class="govuk-table__cell"> 
+              <strong class="govuk-tag govuk-tag--grey">
+              Provisional
+              </strong>
+            </td>
+            
+            <td class="govuk-table__cell">
+              <strong class="govuk-tag govuk-tag--green">
+              Revised
+              </strong>
+            </td>
+            
+            <td class="govuk-table__cell">
+              <strong class="govuk-tag govuk-tag--green">
+              Revised
+                </strong>
+            </td>
+            
+          </tr>
+  
         
           
             <tr class="govuk-table__row">
@@ -1030,28 +1158,44 @@
         
           <th scope="col" class="govuk-table__header"></th>
         
-          <th scope="col" class="govuk-table__header">2016<br>
-            <strong class="govuk-tag govuk-tag--grey">
-            Provisional
-            </strong>
+          <th scope="col" class="govuk-table__header">2021 to 2022
           </th>
         
-          <th scope="col" class="govuk-table__header">2017<br>
-            <strong class="govuk-tag govuk-tag--green">
-            Revised
-            </strong>
+          <th scope="col" class="govuk-table__header">2020 to 2021
           </th>
         
-          <th scope="col" class="govuk-table__header">2018<br>
-            <strong class="govuk-tag govuk-tag--green">
-            Revised
-            </strong>
+          <th scope="col" class="govuk-table__header">2018 to 2019
           </th>
         
         </tr>
         </thead>
         
         <tbody class="govuk-table__body">
+
+          <tr class="govuk-table__row">
+          
+            <th scope="row" class="govuk-table__header">Status</th>
+            
+            <td class="govuk-table__cell"> 
+              <strong class="govuk-tag govuk-tag--grey">
+              Provisional
+              </strong>
+            </td>
+            
+            <td class="govuk-table__cell">
+              <strong class="govuk-tag govuk-tag--green">
+              Revised
+              </strong>
+            </td>
+            
+            <td class="govuk-table__cell">
+              <strong class="govuk-tag govuk-tag--green">
+              Revised
+                </strong>
+            </td>
+            
+          </tr>
+  
         
           
             <tr class="govuk-table__row">
@@ -1157,28 +1301,44 @@
         
           <th scope="col" class="govuk-table__header"></th>
         
-          <th scope="col" class="govuk-table__header">2016<br>
-            <strong class="govuk-tag govuk-tag--grey">
-            Provisional
-            </strong>
+          <th scope="col" class="govuk-table__header">2016
           </th>
         
-          <th scope="col" class="govuk-table__header">2017<br>
-            <strong class="govuk-tag govuk-tag--green">
-            Revised
-            </strong>
+          <th scope="col" class="govuk-table__header">2017
           </th>
         
-          <th scope="col" class="govuk-table__header">2018<br>
-            <strong class="govuk-tag govuk-tag--green">
-            Revised
-            </strong>
+          <th scope="col" class="govuk-table__header">2018
           </th>
         
         </tr>
         </thead>
         
         <tbody class="govuk-table__body">
+
+          <tr class="govuk-table__row">
+          
+            <th scope="row" class="govuk-table__header">Status</th>
+            
+            <td class="govuk-table__cell"> 
+              <strong class="govuk-tag govuk-tag--grey">
+              Provisional
+              </strong>
+            </td>
+            
+            <td class="govuk-table__cell">
+              <strong class="govuk-tag govuk-tag--green">
+              Revised
+              </strong>
+            </td>
+            
+            <td class="govuk-table__cell">
+              <strong class="govuk-tag govuk-tag--green">
+              Revised
+                </strong>
+            </td>
+            
+          </tr>
+  
         
           
             <tr class="govuk-table__row">
@@ -1290,28 +1450,44 @@
         
           <th scope="col" class="govuk-table__header"></th>
         
-          <th scope="col" class="govuk-table__header">2016<br>
-            <strong class="govuk-tag govuk-tag--grey">
-            Provisional
-            </strong>
+          <th scope="col" class="govuk-table__header">2021 to 2022
           </th>
         
-          <th scope="col" class="govuk-table__header">2017<br>
-            <strong class="govuk-tag govuk-tag--green">
-            Revised
-            </strong>
+          <th scope="col" class="govuk-table__header">2020 to 2021
           </th>
         
-          <th scope="col" class="govuk-table__header">2018<br>
-            <strong class="govuk-tag govuk-tag--green">
-            Revised
-            </strong>
+          <th scope="col" class="govuk-table__header">2018 to 2019
           </th>
         
         </tr>
         </thead>
         
         <tbody class="govuk-table__body">
+
+          <tr class="govuk-table__row">
+          
+            <th scope="row" class="govuk-table__header">Status</th>
+            
+            <td class="govuk-table__cell"> 
+              <strong class="govuk-tag govuk-tag--grey">
+              Provisional
+              </strong>
+            </td>
+            
+            <td class="govuk-table__cell">
+              <strong class="govuk-tag govuk-tag--green">
+              Revised
+              </strong>
+            </td>
+            
+            <td class="govuk-table__cell">
+              <strong class="govuk-tag govuk-tag--green">
+              Revised
+                </strong>
+            </td>
+            
+          </tr>
+  
         
           
             <tr class="govuk-table__row">
@@ -1418,7 +1594,7 @@
     <div>
       <dl class="govuk-summary-list">
           <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">Addtional information</dt>
+              <dt class="govuk-summary-list__key">Additional information</dt>
               <dd class="govuk-summary-list__value">
                   {% if data['key-stage-more-detail'] %}
                       {{data['key-stage-more-detail']}}


### PR DESCRIPTION
# Context

Status row added to key stage 4 data to show provisional and revised data.

Status row added to key stage 4 data to show provisional and revised data.

# DevOps ticket:

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/118341

# Changes proposed in this pull request

Status row added to key stage 4 data to show provisional and revised data

# Checklist

- Rebased master
- Cleaned commit history
- Tested by running locally