### PR TITLE
AB#116625 school application form tab

### DIFF
--- a/app/routes/sprint-48/routes.js
+++ b/app/routes/sprint-48/routes.js
@@ -30,6 +30,24 @@ module.exports = function (router) {
   })
 
 
+  router.post('/' + version + '/related/annexb-answer', function (req, res) {
+    // Make a variable to give it the value from the radio buttons on the index page  
+    var annexBanswer = req.session.data['annexBsaved']
+
+    // Check whether the variable matches a condition
+    if (annexBanswer == "Yes") { 
+      // Send user to next page 
+      res.redirect('application_involuntary_conversions')
+
+    }   
+    else if (annexBanswer != "Yes") {
+      //send user to transfers prototype
+      res.redirect('application_saved_involuntary_conversions')
+    }
+
+  })
+
+
 
   router.post('/' + version + '/status/status-answer', function(req, res) {
 

--- a/app/views/sprint-48/related/application_form_url.html
+++ b/app/views/sprint-48/related/application_form_url.html
@@ -18,20 +18,20 @@
       {% if data['returnToSummary'] == 'yes' %}
         <form action="../generate/generate_summary#application-form-url" method="post">
         {% else %}
-        <form action="../related/application_involuntary_conversions" method="post">
+        <form action="../related/application_saved_involuntary_conversions" method="post">
       {% endif %}
       <input hidden type="text" name="returnToSummary" value="no"/>
       <span class="govuk-caption-l">Cheltenham Spa Primary School</span>
-      <h1 class="govuk-heading-l">What is the link for the school application form?</h1>
+      <h1 class="govuk-heading-l">What is the link for the Annex B form?</h1>
       
-      {{ govukDetails({
-        summaryText: "Where to find this link",
-        text: "This is the annex b form saved in your region's SharePoint folder."
-      }) }}
+     
       {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
       {{ govukTextarea({
         name: "application-form-url",
         id: "application-form-url",
+        hint: {
+          text: "The Annex B form is saved in the school's SharePoint folder"
+        },
         value: data["application-form-url"],
         title: "Sharepoint link"
       }) }}

--- a/app/views/sprint-48/related/application_saved_involuntary_conversions.html
+++ b/app/views/sprint-48/related/application_saved_involuntary_conversions.html
@@ -36,19 +36,27 @@
     
     </div>
 
-    {% if data['application-form-url']%}
+    {% if data['application-form-url'] or data['annexBsaved'] =="No"%}
     <div class="govuk-grid-column-full">
       <dl class="govuk-summary-list">
 
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key govuk-!-width-one-third">
-            SharePoint link
+            Have you received a completed Annex B form from the school
           </dt>
           <dd class="govuk-summary-list__value">
             {% if data['application-form-url']%}
-              <a href="{{data['application-form-url']}}" target="_blank" aria-label="School application form (opens in a new tab)">{{data['application-form-url']}}</a>
+            Yes,<br>
+            <a href="{{data['application-form-url']}}" target="_blank" aria-label="School application form (opens in a new tab)">{{data['application-form-url']}}</a>
+             
+
+          
+            {% elseif data['annexBsaved'] =="No"%} 
+            <span>No</span>
+
               {% else %} 
-              <span class="empty">Empty</span>
+              <span>No</span>
+             
             {% endif %}
 
           </dd>
@@ -65,21 +73,42 @@
       {% if data['returnToSummary'] == 'yes' %}
         <form action="../generate/generate_summary#application-form-url" method="post">
         {% else %}
-        <form action="../related/application_saved_involuntary_conversions" method="post">
+        <form action="../related/annexb-answer" method="post">
         {% endif %}
           <input hidden type="text" name="returnToSummary" value="no"/>
-          <h1 class="govuk-heading-l">What is the link for the Annex B form?</h1>
+          <h1 class="govuk-heading-l">Have you saved the school's completed
+            Annex B form in SharePoint?</h1>
+
+            
+            {{data['annexBsaved']}}
+
+            {% from "govuk/components/details/macro.njk" import govukDetails %}
+            {{ govukDetails({
+              summaryText: "What is the Annex B form?",
+              text: "The Annex B form was sent in the directive academy order (DAO) pack to the school. You'll need the completed Annex B form to get the project template ready for advisory board."
+            }) }}
 
           
-          {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
-          {{ govukTextarea({
-            name: "application-form-url",
-            hint: {
-              text: "The Annex B form is saved in the school's SharePoint folder"
-            },
-            id: "application-form-url",
-            title: "Sharepoint link"
+          {{ govukRadios({
+            idPrefix: "annexBsaved",
+            name: "annexBsaved",
+  
+            items: [
+  
+              {
+                value: "Yes",
+                checked:  data['annexBsaved'] === "Yes",
+                text: "Yes"
+              },
+              {
+                value: "No",
+                checked:  data['annexBsaved'] === "No",
+                text: "No"
+              }
+  
+            ]
           }) }}
+
           {{ govukButton({
             text: "Save and continue"
           }) }}

--- a/app/views/sprint-48/related/notes_involuntary_conversions.html
+++ b/app/views/sprint-48/related/notes_involuntary_conversions.html
@@ -25,7 +25,7 @@
                 <a class="app-sub-navigation__link" href="../task_list_involuntary_conversions">Task list</a>
               </li>
               <li class="app-sub-navigation__item">
-                <a class="app-sub-navigation__link"  href="application_involuntary_conversions">School application form</a>
+                <a class="app-sub-navigation__link"  href="application_saved_involuntary_conversions">Annex B form</a>
               </li>
             <!-- Not MVP   <li class="app-sub-navigation__item">
                 <a class="app-sub-navigation__link" href="/related/dates">Project dates</a>

--- a/app/views/sprint-48/task_list_involuntary_conversions.html
+++ b/app/views/sprint-48/task_list_involuntary_conversions.html
@@ -314,7 +314,7 @@
               <a class="app-sub-navigation__link" aria-current="page" href="task_list">Task list</a>
             </li>
             <li class="app-sub-navigation__item">
-              <a class="app-sub-navigation__link"  href="related/application_involuntary_conversions.html">School application form</a>
+              <a class="app-sub-navigation__link"  href="related/application_saved_involuntary_conversions.html">Annex B form</a>
             </li>
             <!-- Not MVP <li class="app-sub-navigation__item">
               <a class="app-sub-navigation__link" href="/related/dates">Project milestones</a>


### PR DESCRIPTION
# Context

School info tab changed to 'Annex B form', and preceding Yes/No question added in tab contents.

School info tab changed to 'Annex B form', and preceding Yes/No question added in tab contents.

# DevOps ticket:

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/116625

# Changes proposed in this pull request

School info tab changed to 'Annex B form', and preceding Yes/No question added in tab contents.

# Checklist

- Rebased master
- Cleaned commit history
- Tested by running locally