### PR TITLE
AB#117568 sponsor template guidance updated

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -15,7 +15,7 @@
   
     <p class="govuk-body-m">New pages / journeys designed in this sprint:</p>
     <ul class="govuk-list govuk-list--bullet govuk-body-m">
-      <!--<li><a href="/sprint-48/conversions-involuntary/start-new-project/search-for-a-school?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Involuntary conversions - search for a school</a></li>-->
+      <!-- <li><a href="/sprint-48/conversions-involuntary/start-new-project/search-for-a-school?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Involuntary conversions - search for a school</a></li>-->
      </ul>
 
     <p class="govuk-body-m">Pages redesigned in this sprint:</p>
@@ -23,6 +23,7 @@
       <li><a href="/sprint-48/overview/set-form-7?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">School and trust information - Form 7 update page - Yes/No/Not sure radios added</a></li>
       <li><a href="/sprint-48/overview/set-dao-date?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">School and trust information - DAO update page - hint text about time of receipt removed</a></li>
       <li><a href="/sprint-48/related/application_saved_involuntary_conversions?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">School application form relabelled as 'Annex B form', and preceding page with Yes/No radios added</a></li>
+      <li><a href="/sprint-48/sponsor-template?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Sponsor template guidance - updated to just match the trust template guidance</a></li>
     </ul>
 
     <p class="govuk-body-m">Useful shortcuts:</p>

--- a/app/views/sprint-48/sponsor-template/index.html
+++ b/app/views/sprint-48/sponsor-template/index.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block beforeContent %}
-<a href="../task_list_involuntary_conversions.html" class="govuk-back-link">Back to task list</a>
+<a href="../task_list" class="govuk-back-link">Back to task list</a>
 {% endblock %}
  
 {% block content %}
@@ -16,30 +16,30 @@
     </li> <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed"> <a class="gem-c-contents-list__link govuk-link"  href="#sharepoint">Getting your template from Sharepoint</a>
     </li> <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed"> <a class="gem-c-contents-list__link govuk-link"  href="#trust">Updating your template in the trust area in KIM</a>
     </li> <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed"> <a class="gem-c-contents-list__link govuk-link"  href="#sponsor">Updating your template in the sponsor area in KIM (if the trust has sponsor status)</a>
-    </li> <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed"> <a class="gem-c-contents-list__link govuk-link"  href="#download">Download your sponsor template from KIM</a>
+    </li> <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed"> <a class="gem-c-contents-list__link govuk-link"  href="#download">Download your trust template from KIM</a>
     </li>
-    <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed"> <a class="gem-c-contents-list__link govuk-link"  href="#send">Send your project template and sponsor template for review</a>
+    <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed"> <a class="gem-c-contents-list__link govuk-link"  href="#send">Send your project template and trust template for review</a>
     </li>
 </ol></nav>
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 <h2 class="govuk-heading-m govuk-!-margin-top-6"><a name="overview"></a>Overview</h2>
-<p class="govuk-body">At the moment, this system does not have access to sponsor templates. </p>
+<p class="govuk-body">At the moment, this system does not have access to multi-academy trust (MAT) or sponsor templates. </p>
     <p class="govuk-body">There are 2 ways you can get these templates outside of this system:</p>
     <ul class="govuk-body">
-        <li>check if there is sponsor template in Sharepoint</li>
-        <li>download a sponsor template from KIM</li>
+        <li>check if there is a MAT or sponsor template in Sharepoint</li>
+        <li>download a MAT or sponsor template from KIM</li>
     </ul>
-<p>If the trust has sponsor status, you will need to use a sponsor template.
+<p>If the trust has sponsor status, you will need to use a sponsor template. If the trust does not have sponsor status you will need a multi-academy trust (MAT) template.
     </p>
 
     <h2 class="govuk-heading-m govuk-!-margin-top-6"><a name="sharepoint"></a>Getting your template from Sharepoint</h2>
 
-    <p class="govuk-body">Check the sponsor folder in Sharepoint because there might already be a template for the trust. </p>
+    <p class="govuk-body">Check the trust or sponsor folder in Sharepoint because there might already be a template for the trust. </p>
         <p class="govuk-body">Make sure the template is not older than 3 months, if it is you will need to download a new template from KIM or request an update from the trust relationship manager.</p>
 
 
-        <h2 class="govuk-heading-m govuk-!-margin-top-6"><a name="trust"></a>Updating your template in the sponsor area in KIM</h2>
+        <h2 class="govuk-heading-m govuk-!-margin-top-6"><a name="trust"></a>Updating your template in the trust area in KIM</h2>
         <p>If the trust does not have sponsor status, use the trust area in KIM to check the template information is up to date.</p>
         <p class="govuk-body"><b>Step 1</b><br>
         Log into KIM, on the left hand side you will see a folder called Infrastructure and Funding. 
@@ -84,15 +84,15 @@ Read through the information to check it’s up to date. Make any changes you ne
 <img src="/public/images/trust-template-guidance/6-Sponsor-template-information.png" alt="Sponsor template information area in KIM">
 
 </br>
-<h2 class="govuk-heading-m govuk-!-margin-top-8"><a name="download"></a>Download your sponsor template from KIM</h2>
-<p>Once you’ve checked the information in your sponsor template is up to date, you can download it to your desktop.</p>
+<h2 class="govuk-heading-m govuk-!-margin-top-8"><a name="download"></a>Download your trust template from KIM</h2>
+<p>Once you’ve checked the information in your MAT or sponsor template is up to date, you can download it to your desktop.</p>
 <P><b>Step 1</b></br>
     On the main view in KIM, select Academy Approval Templates</P>
 </br>
     <img src="/public/images/trust-template-guidance/7-Academy-approval-templates.png" alt="Academy approval templates on  KIM main page">
 </br>
 <P class="govuk-!-margin-top-6"><b>Step 2</b></br>
-    You will be taken to a new page. At the top of the page in the field called Template Type, select if you want a Sponsor. </P>
+    You will be taken to a new page. At the top of the page in the field called Template Type, select if you want a Trust or Sponsor. </P>
         <P>You only need to select Sponsor if the trust has sponsor status.</P>
     </br>
         <img src="/public/images/trust-template-guidance/8-Template-type.png" alt="Template type selection in KIM">       


### PR DESCRIPTION
# Context

Sponsor template guidance page updated - straight copy of trust template guidance other than heading.

Sponsor template guidance page updated - straight copy of trust template guidance other than heading.

# DevOps ticket:

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/117568

# Changes proposed in this pull request

Sponsor template guidance page updated - straight copy of trust template guidance other than heading.

# Checklist

- Rebased master
- Cleaned commit history
- Tested by running locally