### PR TITLE
AB#118355 Rational page redesigned

### DIFF
--- a/app/views/sprint-48/rationale/rationale-summary1-involuntary.html
+++ b/app/views/sprint-48/rationale/rationale-summary1-involuntary.html
@@ -2,7 +2,7 @@
 
 {% block beforeContent %}
 
-<a href="../task_list.html" class="govuk-back-link">Back to task list</a>
+<a href="../task_list_involuntary_conversions.html" class="govuk-back-link">Back to task list</a>
 {% endblock %}
 
 {% block content %}
@@ -11,39 +11,24 @@
     {% if data['returnToSummary'] == 'yes' %}
     <form action="../generate/generate_summary#rationale" method="post">
       {% else %}
-      <form action="../task_list" method="post">
+      <form action="../task_list_involuntary_conversions" method="post">
     {% endif %}
     <input hidden type="text" name="returnToSummary" value="no"/>
   
 <div class="govuk-grid-row"><div class="govuk-grid-column-full">
-  <span class="govuk-caption-l">St. Wilfrid's Primary School</span>
-  <h1 class="govuk-heading-l">Confirm project and trust rationale</h1>
+  <span class="govuk-caption-l">Cheltenham Spa Primary School</span>
+  <h1 class="govuk-heading-l">Confirm trust rationale</h1>
   <p>This information is pre-populated from the <a href="../related/application_newtab" target="_blank">school's application form (opens in a new tab)</a>.</p>
 </div></div>
 
 
         <dl class="govuk-summary-list">
 
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key govuk-!-width-one-quarter">
-              Rationale for project
-            </dt>
-            <dd class="govuk-summary-list__value govuk-!-width-full">
-              {% if data['project-rationale']%}
-              {{data['project-rationale'] | safe}}
-              {% else %} 
-              <span class="empty">Empty</span>
-              {% endif %}</dd>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="project-rationale.html">
-                Change<span class="govuk-visually-hidden">project rationale</span>
-              </a>
-            </dd>
-          </div>
+         
 
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key govuk-!-width-one-quarter">
-              Rationale for the trust or sponsor
+              Rationale for the trust
             </dt>
             <dd class="govuk-summary-list__value  govuk-!-width-two-thirds">
               {% if data['trust-rationale']%}
@@ -53,7 +38,7 @@
               {% endif %}
             </dd>
             <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="sponsor-rationale.html">
+              <a class="govuk-link" href="sponsor-rationale-involuntary.html">
                 Change<span class="govuk-visually-hidden">sponsor rationale</span>
               </a>
             </dd>

--- a/app/views/sprint-48/rationale/sponsor-rationale-involuntary.html
+++ b/app/views/sprint-48/rationale/sponsor-rationale-involuntary.html
@@ -1,0 +1,89 @@
+
+{% extends "layout.html" %}
+
+{% block beforeContent %}
+  
+<a href="javascript:history.back();" class="govuk-back-link">Back</a>
+{% endblock %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+  
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if data['returnToSummary'] == 'yes' %}
+        <form action="../generate/generate_summary#sponsor" method="post">
+        {% else %}
+        <form action="rationale-summary1-involuntary" method="post">
+      {% endif %}
+      <input hidden type="text" name="returnToSummary" value="no"/>
+      <span class="govuk-caption-l">Cheltenham Spa Primary School</span>
+<h1 class="govuk-heading-l">Write the rationale for the trust</h1>
+<p class="govuk-hint">Explain why the trust is a good match for the school.</p>
+    <!-- Not MVP  <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            Help with writing a trust or sponsor rationale
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          <p class="govuk-body">To write your rationale, you could include information about:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>if the school and the trust have a shared vision and values</li>
+        <li>the services the trust can offer the school</li>
+        <li>how the trust can help the school imporve (if needed)</li>
+        <li>how the trust will run the school</li>
+      </ul>
+        </div>
+      </details>-->
+ 
+      <form action="rationale-summary1-involuntary" method="post" novalidate>
+
+        {%- from "govuk/components/textarea/macro.njk" import govukTextarea -%}
+
+{{ govukTextarea({
+id: 'trust-rationale',
+name: 'trust-rationale',
+maxlength: 500,
+rows: 15,
+value: data["trust-rationale"]
+}) }} 
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{{ govukButton({
+  text: "Save and continue"
+}) }}
+
+
+</form>
+
+</div>  
+
+<!-- right hand nav -->    
+<div class="govuk-grid-column-one-third">
+  <aside class="app-related-items" role="complementary">
+  <h2 class="govuk-heading-s" id="subsection-title">
+  Useful information
+  </h2>
+  <nav role="navigation" aria-labelledby="subsection-title">
+  <ul class="govuk-list govuk-!-font-size-16">
+  <li>
+  <a class="govuk-link" href="#">
+
+  </a>
+  </li>
+  <li>
+    <p class="govuk-body-s"><a href="/related/application_newtab" target="application">School application form (opens in a new tab)</a></p>
+  </li>
+
+  </ul>
+  </nav>
+
+  </aside>
+</div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
# Context

Rational page redesigned.

Rational page redesigned.


# DevOps ticket:

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/118355

# Changes proposed in this pull request

Removed rational for sponsor field. (May be reinstated as 'Background information' or similar at a later date.

# Checklist

- Rebased master
- Cleaned commit history
- Tested by running locally