### PR TITLE
AB#118355 Rationale page - reference to school application form removed

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -20,8 +20,8 @@
 
     <p class="govuk-body-m">Pages redesigned in this sprint:</p>
     <ul class="govuk-list govuk-list--bullet govuk-body-m">
-      <li><a href="/sprint-48/related/application_saved_involuntary_conversions?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Annex B form - updated with radio buttons with conditionally revealed question for the SharePoint URL</a></li>
-     
+      <li><a href="/sprint-49/related/application_saved_involuntary_conversions?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Annex B form - updated with radio buttons with conditionally revealed question for the SharePoint URL</a></li>
+      <li><a href="/sprint-49/rationale/rationale-summary1-involuntary?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Rational page - references to school application form removed</a></li>
     </ul>
 
     <p class="govuk-body-m">Useful shortcuts:</p>

--- a/app/views/sprint-48/related/application_saved_involuntary_conversions.html
+++ b/app/views/sprint-48/related/application_saved_involuntary_conversions.html
@@ -80,7 +80,7 @@
             Annex B form in SharePoint?</h1>
 
             
-            {{data['annexBsaved']}}
+           
 
             {% from "govuk/components/details/macro.njk" import govukDetails %}
             {{ govukDetails({

--- a/app/views/sprint-49/rationale/rationale-summary1-involuntary.html
+++ b/app/views/sprint-49/rationale/rationale-summary1-involuntary.html
@@ -18,7 +18,7 @@
 <div class="govuk-grid-row"><div class="govuk-grid-column-full">
   <span class="govuk-caption-l">Cheltenham Spa Primary School</span>
   <h1 class="govuk-heading-l">Confirm trust rationale</h1>
-  <p>This information is pre-populated from the <a href="../related/application_newtab" target="_blank">school's application form (opens in a new tab)</a>.</p>
+  
 </div></div>
 
 
@@ -28,7 +28,7 @@
 
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key govuk-!-width-one-quarter">
-              Rationale for the trust
+              Rationale for the trust or sponsor
             </dt>
             <dd class="govuk-summary-list__value  govuk-!-width-two-thirds">
               {% if data['trust-rationale']%}

--- a/app/views/sprint-49/rationale/sponsor-rationale-involuntary.html
+++ b/app/views/sprint-49/rationale/sponsor-rationale-involuntary.html
@@ -20,7 +20,7 @@
       {% endif %}
       <input hidden type="text" name="returnToSummary" value="no"/>
       <span class="govuk-caption-l">Cheltenham Spa Primary School</span>
-<h1 class="govuk-heading-l">Write the rationale for the trust</h1>
+<h1 class="govuk-heading-l">Write the rationale for the trust or sponsor</h1>
 <p class="govuk-hint">Explain why the trust is a good match for the school.</p>
     <!-- Not MVP  <details class="govuk-details" data-module="govuk-details">
         <summary class="govuk-details__summary">

--- a/app/views/sprint-49/related/application_form_url.html
+++ b/app/views/sprint-49/related/application_form_url.html
@@ -22,7 +22,13 @@
       {% endif %}
       <input hidden type="text" name="returnToSummary" value="no"/>
       <span class="govuk-caption-l">Cheltenham Spa Primary School</span>
-      <h1 class="govuk-heading-l">What is the link for the Annex B form?</h1>
+      <h1 class="govuk-heading-l">Have you saved the school's completed Annex B form in SharePoint?</h1>
+
+      {% from "govuk/components/details/macro.njk" import govukDetails %}
+      {{ govukDetails({
+        summaryText: "What is the Annex B form?",
+        text: "The Annex B form was sent in the directive academy order (DAO) pack to the school. You'll need the completed Annex B form to get the project template ready for advisory board."
+      }) }}
       
      
       {% from "govuk/components/radios/macro.njk" import govukRadios %}

--- a/app/views/sprint-49/related/application_saved_involuntary_conversions.html
+++ b/app/views/sprint-49/related/application_saved_involuntary_conversions.html
@@ -85,6 +85,12 @@
           <h1 class="govuk-heading-l">Have you saved the school's completed
             Annex B form in SharePoint?</h1>
 
+            {% from "govuk/components/details/macro.njk" import govukDetails %}
+            {{ govukDetails({
+              summaryText: "What is the Annex B form?",
+              text: "The Annex B form was sent in the directive academy order (DAO) pack to the school. You'll need the completed Annex B form to get the project template ready for advisory board."
+            }) }}
+
             {% from "govuk/components/radios/macro.njk" import govukRadios %}
             {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
               {% set yesHtml %}


### PR DESCRIPTION
# Context

Rationale page minor edit

Rationale page minor edit

# DevOps ticket:

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/118355

# Changes proposed in this pull request

Reference to school application form removed

# Checklist

- Rebased master
- Cleaned commit history
- Tested by running locally