### PR TITLE
AB#120227 Change Start new transfer button to primary button

### DIFF
--- a/app/views/sprint-49/transfers/projects-list-transfers-original.html
+++ b/app/views/sprint-49/transfers/projects-list-transfers-original.html
@@ -24,7 +24,7 @@
       {{ govukButton({
         text: "Start a new transfer project",
         href: "#",
-        isStartButton: true
+        isStartButton: false
       }) }}
     </div>
   </div>

--- a/app/views/sprint-49/transfers/projects-list-transfers-results.html
+++ b/app/views/sprint-49/transfers/projects-list-transfers-results.html
@@ -36,7 +36,7 @@
       {{ govukButton({
         text: "Start a new transfer project",
         href: "#",
-        isStartButton: true
+        isStartButton: false
       }) }}
     </div>
   </div>

--- a/app/views/sprint-49/transfers/projects-list-transfers.html
+++ b/app/views/sprint-49/transfers/projects-list-transfers.html
@@ -24,7 +24,7 @@
       {{ govukButton({
         text: "Start a new transfer project",
         href: "#",
-        isStartButton: true
+        isStartButton: false
       }) }}
     </div>
   </div>


### PR DESCRIPTION
# Context

Change 'Start new transfer' button to a Primary Button

Change 'Start new transfer' button to a Primary Button

# DevOps ticket:

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/117567

# Changes proposed in this pull request

Change 'Start new transfer' button to a Primary Button

# Checklist

- Rebased master
- Cleaned commit history
- Tested by running locally