### PR TITLE
AB#118374 Search for a school updated with auto populate functionality

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -24,10 +24,19 @@
     <ul class="govuk-list govuk-list--bullet govuk-body-m">
       <li><a href="/sprint-49/related/application_saved_involuntary_conversions?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Annex B form - updated with radio buttons with conditionally revealed question for the SharePoint URL</a></li>
       <li><a href="/sprint-49/rationale/rationale-summary1-involuntary?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Rational page - references to school application form removed</a></li>
-      <li><a href="/sprint-48/conversions-involuntary/overview/summary1-involuntary?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Involuntary conversions - school and trust info - form 7 split into two rows with date row appearing if received set to yes</a></li>
-      <li><a href="/sprint-48/conversions-involuntary/overview/set-form-7?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Involuntary conversions - form 7 received</a></li>
-      <li><a href="/sprint-48/conversions-involuntary/overview/set-form-7-date?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Involuntary conversions - date form 7 received</a></li>
+      <li><a href="/sprint-49/conversions-involuntary/overview/summary1-involuntary?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Involuntary conversions - school and trust info - form 7 split into two rows with date row appearing if received set to yes</a></li>
+      <li><a href="/sprint-49/conversions-involuntary/overview/set-form-7?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Involuntary conversions - form 7 received</a></li>
+      <li><a href="/sprint-49/conversions-involuntary/overview/set-form-7-date?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Involuntary conversions - date form 7 received</a></li>
+      <li><a href="/sprint-49/conversions-involuntary/start-new-project/search-for-a-school?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Involuntary conversions - search for a school - changed to autopopulate version</a></li>
+      <li><a href="/sprint-49/conversions-involuntary/start-new-project/search-for-a-trust?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Involuntary conversions - search for a trust - changed to autopopulate version</a></li>
+      <li><a href="/sprint-49/conversions-involuntary/start-new-project/check-school-and-trust-details?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Involuntary conversions - check school and trust details - Trust Companies House number row added</a></li>
     </ul>
+
+    <p class="govuk-body-m">Pages removed in this sprint:</p>
+    <ul class="govuk-list govuk-list--bullet govuk-body-m">  
+      <li><!--<a href="/sprint-49/conversions-involuntary/start-new-project/select-school?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">-->Involuntary conversions - select school - no longer needed with autopopulate search<!--</a>--></li>
+      <li><!--<a href="/sprint-49/conversions-involuntary/start-new-project/select-trust?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">-->Involuntary conversions - select trust - no longer needed with autopopulate search<!--</a>--></li>
+     </ul>
 
     <p class="govuk-body-m">Useful shortcuts:</p>
     <ul class="govuk-list govuk-list--bullet govuk-body-m">

--- a/app/views/sprint-49/conversions-involuntary/start-new-project/check-school-and-trust-details.html
+++ b/app/views/sprint-49/conversions-involuntary/start-new-project/check-school-and-trust-details.html
@@ -63,7 +63,7 @@
                         Name
                     </dt>
                     <dd class="govuk-summary-list__value">
-                        Cheltenham Primary School
+                        Cheltenham Spa Primary School
                     </dd>
                     <dd class="govuk-summary-list__actions">
                         <a class="govuk-link" href="./add-outgoing-trust-name">
@@ -175,6 +175,16 @@
                     </dt>
                     <dd class="govuk-summary-list__value">
                         10060980
+                    </dd>
+                    <dd class="govuk-summary-list__value"></dd>
+                </div>
+
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Companies House Number
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        09613632
                     </dd>
                     <dd class="govuk-summary-list__value"></dd>
                 </div>

--- a/app/views/sprint-49/conversions-involuntary/start-new-project/search-for-a-school.html
+++ b/app/views/sprint-49/conversions-involuntary/start-new-project/search-for-a-school.html
@@ -4,29 +4,71 @@
 
 
 {% block formQuestions %}
-    <form action="./select-school" method="post" novalidate>
+    <form action="./search-for-a-trust" method="post" novalidate>
         
 
+      
         {% set pageHeading %}
             What is the school name?
         {% endset %}
 
-        {{ govukInput({
+
+        {{ govukSelect({
             label: {
                 html: pageHeading,
                 classes: "govuk-label--xl",
                 isPageHeading: true
             },
             hint: {
-                text: "Search by name or URN (Unique Reference Number)."
+              text: "Search by name or URN (Unique Reference Number)."
             },
             id: "school-name",
-            name: "school-name"
-        }) }}
+            name: "school-name",
+            value: data['school-name'],
+            items: [
+              {
+                value: "",
+                text: ""
+              },
+              {
+                value: "Cheltenham Spa Primary School",
+                text: "Cheltenham Spa Primary School",
+                selected: checked("school-name", "Cheltenham Spa Primary School")
+              },
+              {
+                value: "Cheltenham Spa Secondary School",
+                text: "Cheltenham Spa Secondary School",
+                selected: checked("school-name", "Cheltenham Spa Secondary School")
+              },
+              {
+                value: "Cheltenham Boys School",
+                text: "Cheltenham Boys School",
+                selected: checked("school-name", "Cheltenham Boys School")
+              },
+              {
+                value: "Cheltenham Girls School",
+                text: "Cheltenham Girls School",
+                selected: checked("school-name", "Cheltenham Girls School")
+              }
+            ]
+          }) }}
 
-        {{ govukButton({
-            text: "Search"
+
+
+
+          {{ govukButton({
+            text: "Continue"
         }) }}
+          
+         
+
+
     </form>
-
+    <script>
+    document.addEventListener("DOMContentLoaded", () => {
+      accessibleAutocomplete.enhanceSelectElement({
+        selectElement: document.querySelector('#school-name')
+      })
+    });
+    </script>
 {% endblock %}

--- a/app/views/sprint-49/conversions-involuntary/start-new-project/search-for-a-trust.html
+++ b/app/views/sprint-49/conversions-involuntary/start-new-project/search-for-a-trust.html
@@ -4,29 +4,60 @@
 
 
 {% block formQuestions %}
-    <form action="./select-trust" method="post" novalidate>
+    <form action="./check-school-and-trust-details" method="post" novalidate>
         
 
         {% set pageHeading %}
             What is the trust name?
         {% endset %}
 
-        {{ govukInput({
+        {{ govukSelect({
             label: {
                 html: pageHeading,
                 classes: "govuk-label--xl",
                 isPageHeading: true
             },
             hint: {
-                text: "Search by name, UKPRN or Companies House Number."
+              text: "Search by name, UKPRN or Companies House number."
             },
             id: "trust-name",
-            name: "trust-name"
-        }) }}
+            name: "trust-name",
+            value: data['trust-name'],
+            
+            items: [
+              {
+                value: "",
+                text: ""
+              },
+              {
+                value: "Gloucestershire Academy Trust (10060980) - Companies House number: 09613632",
+                text: "Gloucestershire Academy Trust (10060980) - Companies House number: 09613632",
+                selected: checked("trust-name", "Gloucestershire Academy Trust (10060980) - Companies House number: 09613632")
+              },
+              {
+                value: "Gloucestershire North Schools Trust (10058638) - Companies House number: 07561574",
+                text: "Gloucestershire North Schools Trust (10058638) - Companies House number: 07561574",
+                selected: checked("trust-name", "Gloucestershire North Schools Trust (10058638) - Companies House number: 07561574")
+              },
+              {
+                value: "Gloucestershire South Schools Trust (10058757) - Companies House number: 07641004",
+                text: "Gloucestershire South Schools Trust (10058757) - Companies House number: 07641004",
+                selected: checked("trust-name", "Gloucestershire South Schools Trust (10058757) - Companies House number: 07641004")
+              }
+            ]
+          }) }}
 
-        {{ govukButton({
-            text: "Search"
-        }) }}
+          {{ govukButton({
+            text: "Continue"
+            }) }}
+      
+    
     </form>
-
+    <script>
+        document.addEventListener("DOMContentLoaded", () => {
+          accessibleAutocomplete.enhanceSelectElement({
+            selectElement: document.querySelector('#trust-name')
+          })
+        });
+        </script>
 {% endblock %}

--- a/app/views/sprint-49/conversions-involuntary/start-new-project/select-trust.html
+++ b/app/views/sprint-49/conversions-involuntary/start-new-project/select-trust.html
@@ -34,7 +34,7 @@
               value: "gloucestershire-south-schools-trust",
               text: "Gloucestershire South Schools Trust (10058757)",
               hint: {
-                text: "Companies House number: 07641004"
+                text: "Companies House Number: 07641004"
               }
             }
           ]

--- a/app/views/sprint-49/projects-list-involuntary-conversions-after.html
+++ b/app/views/sprint-49/projects-list-involuntary-conversions-after.html
@@ -266,7 +266,7 @@
               Route: Involuntary conversion</br>
               Application to join a trust: Gloucestershire Academy Trust</br>
               Local authority: Gloucestershire</br>
-              Delivery officer: <!--span class="empty">Empty</span--><strong>Alex James</strong>
+              Delivery officer: <span class="empty">Empty</span>
               </p>
             </td>
             <td class="govuk-table__cell govuk-table__cell prepare-text-align-right">
@@ -274,9 +274,9 @@
                 <strong class="govuk-tag govuk-tag--yellow">Pre Advisory Board</strong>
               </p>
               <p class="govuk-hint  govuk-!-margin-top-0">
-                Project created date: 5 January 2021</br>
-                Advisory Board date: 1 June 2021</br>
-                Opening date: 1 July 2021
+                Project created date: 8 February 2023</br>
+                Advisory Board date: <span class="empty">Empty</span></br>
+                Opening date: <span class="empty">Empty</span>
               </p>
             </td>   
           </tr>

--- a/app/views/sprint-49/projects-list-involuntary-conversions-before.html
+++ b/app/views/sprint-49/projects-list-involuntary-conversions-before.html
@@ -26,7 +26,7 @@
     <p class="govuk-body">Use this service to start a new involuntary conversion project or update an existing conversion project.</p>
 
 
-    <a href="/sprint-47/conversions-involuntary/start-new-project/search-for-a-school?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null" role="button" draggable="false" class="govuk-button <!--govuk-button--start-->" data-module="govuk-button">
+    <a href="/sprint-49/conversions-involuntary/start-new-project/search-for-a-school?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null" role="button" draggable="false" class="govuk-button <!--govuk-button--start-->" data-module="govuk-button">
       Start a new involuntary conversion project
       <!--
       <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">


### PR DESCRIPTION
# Context

Search for a school updated with auto populate functionality

Search for a trust updated with auto populate functionality

# DevOps ticket:

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/118374
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/118378

Changes proposed in this pull request

Search for a school/trust pages updated with auto populate functionality
Search results/ select school/trust pages removes as no longer required

# Checklist

- Rebased master
- Cleaned commit history
- Tested by running locally