### PR TITLE
AB#120077 Form a MAT Trust info version 3

### DIFF
--- a/app/views/sprint-49/form-a-mat/application-glos.html
+++ b/app/views/sprint-49/form-a-mat/application-glos.html
@@ -1,0 +1,1182 @@
+{% extends "layout.html" %}
+
+{% block beforeContent %}
+<a href="./task_list_cheltenham.html" class="govuk-back-link">Back to task list</a>
+{% endblock %}
+
+{% block content %}
+          
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+
+      <span class="govuk-caption-xl">URN 101573</span>
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
+        Gloucester Primary School</h1>
+        {% if data['htb-date']%}
+        <div class="govuk-inset-text"><h4 class="govuk-heading-m">HTB date</h4>
+        <p>HTB date for this project is {{ data['htb-date']}}</p></div> 
+         {% else %} 
+         {% endif %}
+<nav class="app-sub-navigation" aria-label="sub menu">
+  <ul class="app-sub-navigation__list govuk-!-margin-top-6">
+
+    <li class="app-sub-navigation__item">
+      <a class="app-sub-navigation__link" href="task_list_gloucester.html">Task list</a>
+    </li>
+    <li class="app-sub-navigation__item">
+      <a class="app-sub-navigation__link" aria-current="page" href="#">School application form</a>
+    </li>
+    <!-- Not MVP <li class="app-sub-navigation__item">
+      <a class="app-sub-navigation__link" href="/related/dates">Project milestones</a>
+    </li> -->
+    <li class="app-sub-navigation__item">
+      <a class="app-sub-navigation__link"  href="#">Project notes</a>
+    </li>
+    <li class="app-sub-navigation__item">
+      <a class="app-sub-navigation__link"  href="./trust-information-alt.html">Trust information</a>
+    </li>
+    <li class="app-sub-navigation__item">
+      <a class="app-sub-navigation__link"  href="./projects-other-mat-glos.html">Other schools in this MAT</a>
+    </li>
+</ul>
+
+</nav>
+</div>
+<div class="govuk-grid-column-full">
+
+<p><a href="application_newtab" target="application">Open school application form in a new tab</a></p>
+  <h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">School application form</h2>
+
+  <nav class="gem-c-contents-list" aria-label="Pages in this guide" role="navigation" data-module="gem-track-click"> <h2 class="gem-c-contents-list__title"> Contents</h2>
+    <ol class="gem-c-contents-list__list">
+        <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed"> <a class="gem-c-contents-list__link govuk-link"  href="#overview"> Overview</a></li> 
+        <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed"> <a class="gem-c-contents-list__link govuk-link"  href="#about">About the conversion</a></li>
+        <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed"> <a class="gem-c-contents-list__link govuk-link"  href="#further_info">Further information</a></li>
+        <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed"> <a class="gem-c-contents-list__link govuk-link"  href="#finances">Finances</a></li>
+        <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed"> <a class="gem-c-contents-list__link govuk-link"  href="#numbers">Future pupil numbers</a></li>
+        <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed"> <a class="gem-c-contents-list__link govuk-link"  href="#land">Land and buildings</a></li>
+        <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed"> <a class="gem-c-contents-list__link govuk-link"  href="#grant">Pre-opening support grant</a></li>
+        <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed"> <a class="gem-c-contents-list__link govuk-link"  href="#consultation">Consultation</a></li>
+        <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed"> <a class="gem-c-contents-list__link govuk-link"  href="#declaration">Declaration</a></li></li>
+    </ol></nav>
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+    <a name="overview"></a><h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Overview</h2>
+        <dl class="govuk-summary-list  govuk-!-margin-top">
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Application to join
+    </dt>
+    <dd class="govuk-summary-list__value">
+      Gloucester Academy Trust with Cheltenham Spa Primary School
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Application reference
+    </dt>
+    <dd class="govuk-summary-list__value">
+      AS_100006
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Lead applicant
+    </dt>
+    <dd class="govuk-summary-list__value">
+      Bob Roberts
+    </dd>
+  </div>
+</dl>
+
+<h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Trust details</h3>
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Trust name
+    </dt>
+    <dd class="govuk-summary-list__value">
+      Gloucester Academy Trust
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Upload evidence that the trust consents to the school joining
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <a href="#">consent_dynamics.docx</a>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Will there be any changes to the governance of the trust due to the school joining?
+    </dt>
+    <dd class="govuk-summary-list__value">
+      Yes
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      What are the changes?
+    </dt>
+    <dd class="govuk-summary-list__value">
+      The trust will get a new CEO and CFO to make sure the finances of the school are in line with other schools in the trust.
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Will there be any changes at a local level due to this school joining?
+    </dt>
+    <dd class="govuk-summary-list__value">
+      Yes
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      What are the changes and how do they fit into the current lines of accountability in the trust
+    </dt>
+    <dd class="govuk-summary-list__value">
+      Some explanation of this.
+    </dd>
+  </div>
+</dl>
+
+
+
+<a name="about"></a><h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">About the conversion</h2>
+<h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">The school joining the trust</h3>
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      The name of the school
+    </dt>
+    <dd class="govuk-summary-list__value">
+      Cheltenham Spa Primary School
+    </dd>
+  </div>
+</dl>
+
+  <h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Contact details</h3>
+  <dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Name of headteacher
+    </dt>
+    <dd class="govuk-summary-list__value">
+     Garth Brown
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Headteacher's email address
+    </dt>
+    <dd class="govuk-summary-list__value">
+      garth.brown@cheltenhamspaprimary.edu.uk
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Headteacher's phone number
+    </dt>
+    <dd class="govuk-summary-list__value">
+     0987 664 547
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Name of the chair of the Governing Body
+    </dt>
+    <dd class="govuk-summary-list__value">
+      Arna Siggurdottier
+    </dd>
+  </div>
+<div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Chair's email address
+    </dt>
+    <dd class="govuk-summary-list__value">
+     arna.siggurdottier@gloucesteracademytrust.co.uk
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Chair's phone number
+    </dt>
+    <dd class="govuk-summary-list__value">
+     0972 345 119
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Who is the main contact for the conversion?
+    </dt>
+    <dd class="govuk-summary-list__value">
+     Someone else
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Name of main contact
+    </dt>
+    <dd class="govuk-summary-list__value">
+     Carol Berry
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Main contact's email address
+    </dt>
+    <dd class="govuk-summary-list__value">
+     carol.b@gmail.com
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Main contact's phone number
+    </dt>
+    <dd class="govuk-summary-list__value">
+     0759 312 344
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Main contact's role
+    </dt>
+    <dd class="govuk-summary-list__value">
+     Trust CEO
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Approver's name
+    </dt>
+    <dd class="govuk-summary-list__value">
+     Garth Brown
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Approver's email address
+    </dt>
+    <dd class="govuk-summary-list__value">
+    garth.brown@cheltenhamspaprimary.edu.uk
+    </dd>
+  </div>
+</dl>
+
+
+<h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Date for conversion</h3>
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Do you want the conversion to happen on a particular date
+    </dt>
+    <dd class="govuk-summary-list__value">
+      Yes
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Preferred date
+    </dt>
+    <dd class="govuk-summary-list__value">
+     01/11/2021
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Explain why you want to convert on this date
+    </dt>
+    <dd class="govuk-summary-list__value">
+     It is in line with the start of the school term meaning there will be less disruption for students.
+    </dd>
+  </div>
+</dl>
+
+<h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Reasons for joining</h3>
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Why does the school want to join this trust in particular?
+    </dt>
+    <dd class="govuk-summary-list__value">
+     <p>The Diocesan Academy Policy (December 2019) states the expectation that all schools within the Diocese of Warrington will convert to academy status within one of the four Diocesan Catholic Education Trusts by July 2022. The resulting growth plan earmarks our school for transition into Dynamics Trust. This Catholic trust model ensures every school has its place and no individual school is left isolated or vulnerable, in a rapidly changing environment. It also ensures that the uniqueness of each individual school is celebrated and the unique contribution of each is recognised and appreciated. The Trust has an experienced Director of Learning and Teaching who effectively co-ordinates some central school effectiveness provision to monitor school performance/ achievement and ensures support is provided and matched to need, mainly as brokerage, within the system leadership structure.</p><p>The Trust’s school improvement model is based on the new Northern Alliance, aiming to build capacity and improve educational standards in the North of England. In the words of Sir David Carter “the Northern Alliance is an innovative partnership which illustrates the strength of collaboration that is emerging as part of our developing self-improving school system.” Through the excellent, collaborative work delivered to date and first-hand experience of supporting other schools/academies across the North West, the expanding Trust has the expertise to ensure that each partner school can benefit, as a robust infrastructure to support future growth is built. Careful monitoring of each school by the CEO, School Improvement Partner, Headteachers and Trust Board ensures that high quality teaching takes place across the Trust. There is currently excellent practice demonstrated within the Primary and Secondary partners within the existing Dynamics Trust.</p>   
+    </dd>
+  </div></dl>
+
+  <h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Name changes</h3>
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Is the school planning to change its name when it becomes an academy?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Yes
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        What's the proposed new name?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Cheltenham Spa Academy
+      </dd>
+    </div>
+  </dl>
+
+
+  <a name="further_info"></a> <h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Further information</h2>
+  <h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Additional details</h3>
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        What will the school bring to the trust they are joining?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Our school’s highly motivated team will contribute to the expansion of the range of expertise at primary level in the Trust and our success can be demonstrated through the high quality care and teaching that is delivered at St Wilfrid's Primary School. As reported by OFSTED in 2017, the good quality of education was maintained since the previous OFSTED inspection and it was also reported that there is a determination that academic standards continue to improve, complimenting the Trust’s aim to offer outstanding education provision to all children. Our school is committed to knowing all our pupils, their families and their needs which can be illustrated in the improvement in attendance where the close working relationship with parents and carers was considered by inspectors to be a contributing factor. This supports the Trust’s value of close working and supportive relationships with its parents and carers. Working closely with St Mary’s Catholic School and Sixth Form, the Trust school which our students feed in to, community links and relationships will be developed and strengthened as a result of our School joining the Trust.</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Have Ofsted recently inspected the school but not published the report yet?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Yes</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Provide the inspection date and short summary of the outcome
+      </dt>
+      <dd class="govuk-summary-list__value">
+        12/11/2021. The outcome was that Ofsted were impressed with the progress made by the school to improve behaviour of the students.</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Are there any safeguarding investigations ongoing at the school?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Yes</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Details of the investigation
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Some explanation here.</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Is the school part of a local authority reorganisation?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Yes</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Details of the reorganisation
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Some explanation here.</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Is the school part of any local authority closure plans?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Yes</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Details of the closure plan
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Some explanation here.</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Is your school linked to a diocese?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Yes</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Name of diocese?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Diocese of Gloucestershire</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+       Upload a letter of consent from the diocese
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <a href="#">constent-from-diocese.docx</a></dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Is your school part of a federation?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        No</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Is the school supported by a foundation, trust or other body (e.g. parish council) that appoints foundation governors?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Yes</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Name of this body
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Joe Bloggs Foundation</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Upload their letter of consent
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <a href="#">constent-from-foundation.docx</a></dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Does the school currently have an exemption from providing broadly Christian collective worship issued by the local Standing Committee on Religious Education (SACRE)?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Yes</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        When does the exemption end?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        4/5/2023</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Please provide a list of your main feeder schools
+      </dt>
+      <dd class="govuk-summary-list__value">
+        St Mary's Catholic School, St Catherine's Nursery School</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        The school's Governing Body must have passed a resolution to apply to convert to academy status. Upload a copy of the school’s consent to converting and joining the trust.
+      </dt>
+      <dd class="govuk-summary-list__value">
+      <a href="#"> consent.docx</a></dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+      Has an equalities impact assessment been carried out and considered by the governing body?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Yes</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        When the governing body considered the equality duty what did they decide?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        That the Secretary of State's decision is unlikely to disproportionately affect any particular person or group who share protected charateristics.</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Do you want to add any further information?</dt>
+      <dd class="govuk-summary-list__value">
+      Yes</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Add any further information</dt>
+      <dd class="govuk-summary-list__value">
+      Some further information.</dd>
+    </div>
+  </dl>
+
+
+  <a name="finances"></a> <h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Finances</h2>
+  <h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Previous financial year</h3>
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        End of previous financial year
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        31/03/2021
+      </dd>
+    </div>
+  </dl>
+
+
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+      Revenue carry forward at the end of the previous financial year (31 March)
+    </dt>
+    <dd class="govuk-summary-list__value">
+      - £169,093.00
+    </dd>
+  </div>
+</dl>
+
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+      Surplus or deficit?
+    </dt>
+    <dd class="govuk-summary-list__value">
+      Deficit
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+    Explain the reasons for the deficit, how the school plans to deal with it, and the recovery plan
+  </dt>
+  <dd class="govuk-summary-list__value">
+    Some explanation here.
+  </dd>
+</div>
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+  Upload the school's recovery plan
+</dt>
+<dd class="govuk-summary-list__value">
+  No upload provided
+</dd>
+</div>
+</dl>
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+  </div>
+</dl>
+
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+    Capital carry forward at the end of the previous financial year (31 March)
+  </dt>
+  <dd class="govuk-summary-list__value">
+    - £20,000.00
+  </dd>
+</div>
+</dl>
+
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+    Surplus or deficit?
+  </dt>
+  <dd class="govuk-summary-list__value">
+    Deficit
+  </dd>
+</div>
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+  Explain the reasons for the deficit, how the school plans to deal with it, and the recovery plan
+</dt>
+<dd class="govuk-summary-list__value">
+  Some explanation here.
+</dd>
+</div>
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+Upload the school's recovery plan
+</dt>
+<dd class="govuk-summary-list__value">
+No upload provided
+</dd>
+</div>
+</dl>
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+</div>
+</dl>
+
+<h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Current financial year</h3>
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        End of current financial year
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        31/03/2022
+      </dd>
+    </div>
+  </dl>
+
+
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+      Forecasted revenue carry forward at the end of the current financial year (31 March)
+    </dt>
+    <dd class="govuk-summary-list__value">
+      - £10.00
+    </dd>
+  </div>
+</dl>
+
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+      Surplus or deficit?
+    </dt>
+    <dd class="govuk-summary-list__value">
+      Deficit
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+    Explain the reasons for the deficit, how the school plans to deal with it, and the recovery plan
+  </dt>
+  <dd class="govuk-summary-list__value">
+    Some explanation here.
+  </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+  Upload the school's recovery plan
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <a href="#"> recovery-plan.docx</a>
+  </dd>
+  </div>
+  </dl>
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+  </div>
+</dl>
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+    Forecasted capital carry forward at the end of the current financial year (31 March)
+  </dt>
+  <dd class="govuk-summary-list__value">
+    - £20.00
+  </dd>
+</div>
+</dl>
+
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+    Surplus or deficit?
+  </dt>
+  <dd class="govuk-summary-list__value">
+    Deficit
+  </dd>
+</div>
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+  Explain the reasons for the deficit, how the school plans to deal with it, and the recovery plan
+</dt>
+<dd class="govuk-summary-list__value">
+  Some explanation here.
+</dd>
+</div>
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+Upload the school's recovery plan
+</dt>
+<dd class="govuk-summary-list__value">
+  <a href="#">recovery-plan.docx</a>
+</dd>
+</div>
+</dl>
+<h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Next financial year</h3>
+<dl class="govuk-summary-list">
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    End of current financial year
+
+  </dt>
+  <dd class="govuk-summary-list__value">
+    31/03/2022
+  </dd>
+</div>
+</dl>
+
+
+<dl class="govuk-summary-list">
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+  Forecasted revenue carry forward at the end of the next financial year (31 March)
+</dt>
+<dd class="govuk-summary-list__value">
+  - £143,931.00
+</dd>
+</div>
+</dl>
+
+<dl class="govuk-summary-list">
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+  Surplus or deficit?
+</dt>
+<dd class="govuk-summary-list__value">
+  Deficit
+</dd>
+</div>
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+  Explain the reasons for the deficit, how the school plans to deal with it, and the recovery plan
+</dt>
+<dd class="govuk-summary-list__value">
+  Some explanation here.
+</dd>
+</div>
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+Upload the school's recovery plan
+</dt>
+<dd class="govuk-summary-list__value">
+  <a href="#">recovery-plan.docx</a>
+</dd>
+</div>
+</dl>
+<dl class="govuk-summary-list">
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+Forecasted capital carry forward at the end of the next financial year (31 March)
+</dt>
+<dd class="govuk-summary-list__value">
+- £30,345.00
+</dd>
+</div>
+</dl>
+
+<dl class="govuk-summary-list">
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+Surplus or deficit?
+</dt>
+<dd class="govuk-summary-list__value">
+Deficit
+</dd>
+</div>
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+  Explain the reasons for the deficit, how the school plans to deal with it, and the recovery plan
+</dt>
+<dd class="govuk-summary-list__value">
+  Some explanation here.
+</dd>
+</div>
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+Upload the school's recovery plan
+</dt>
+<dd class="govuk-summary-list__value">
+  <a href="#">recovery-plan.docx</a>
+</dd>
+</div>
+</dl>
+<h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Loans</h3>
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Are there any exisiting loans?
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Yes
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Total amount
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        £3000.00
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Purpose of the loan
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Some explanation here.
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Loan provider
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        ABC Loan Provider
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Interest rate
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        2%
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Schedule of repayment
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        £200 per month
+      </dd>
+    </div>
+  </dl>
+  <h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Financial leases</h3>
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Are there any exisiting leases?
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Yes
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Details of the term of the finance lease agreement
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Some explanation here.
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Repayment value
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        £10,000.00
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Interest rate chargable
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        5%
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Value of payments made to date
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        £2000.00
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        What was the finance lease for?
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        To pay for IT equipment
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Value of the assests at the start of the finance lease agreement
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        £5000.00
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Who is responsible for the insurance, repair and maintenance of the assets covered?
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        The IT specialists at the school.
+      </dd>
+    </div>
+  </dl>
+
+  <h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Financial investigations</h3>
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Are there any financial investigations ongoing at the school?
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Yes
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Provide a bried summary of the investigation
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Some explanation here.
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Is the trust you are joining aware of the investigation
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Yes
+      </dd>
+    </div>
+  </dl>
+
+
+  <a name="numbers"></a> <h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Future pupil numbers</h2>
+      <h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Details</h3>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Projected pupil numbers on roll in the year the academy opens (year 1)
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+            189
+          </dd>
+        </div>
+      </dl>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Projected pupil numbers on roll in the following year after the academy has opened (year 2)
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+            189
+          </dd>
+        </div>
+      </dl>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Projected pupil numbers on roll in the following year (year 3)
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+            189
+          </dd>
+        </div>
+      </dl>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            What do you base these projected numbers on?
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+            We expect 30 pupils intake each year in Reception. This is typical for our school but we predict a decrease in future due to a few nursery schools in the area closing. By joining Dynamics Trust, we expect we will have more opportunity to encourage more pupils to the school. The trust's track record of improving pupil intake is one of the reasons we want to join this trust and explains the increase we predict.
+          </dd>
+        </div>
+      </dl>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            What is the school's published admissions number (PAN)?
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+          210
+          </dd>
+        </div>
+      </dl>
+
+      <a name="land"></a><h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Land and buildings</h2>
+      <h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Details</h3>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            As far as you're aware, who owns or holds the school's buildings and land?
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+            The Diocese of Warrington owns the building and the land. The LA owns the playing fields.
+          </dd>
+        </div>
+      </dl>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Are there any current planned building works?
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Yes
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Provide details of the works, how they'll be funded and whether the funding will be affected by the conversion
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Some explanation here.
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            When is the scheduled completion date
+          </dt>
+          <dd class="govuk-summary-list__value">
+            19/1/2022
+          </dd>
+        </div>
+      </dl>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Are there any shared facilities on site?
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Yes
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            List the facilities and the school's plan for them after converting
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Some explanation here.
+          </dd>
+        </div>
+      </dl>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Has the school had any grants from Sport England, the Big Lottery Fund, or the Football Federation?
+          </dt>
+          <dd class="govuk-summary-list__value">
+          Yes
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Which bodies awarded the grants and what facilities did they fund?
+          </dt>
+          <dd class="govuk-summary-list__value">
+          Some explanation here.
+          </dd>
+        </div>
+      </dl>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+          Is the school part of a Private Finance Intiative (PFI) scheme?
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+          Yes
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            What kind of PFI Scheme is your school part of?
+          </dt>
+          <dd class="govuk-summary-list__value">
+          Some explanation here.
+          </dd>
+        </div>
+      </dl>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+          Is the school part of a Priority School Building Programme?
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+          No
+          </dd>
+        </div>
+      </dl>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+          Is the school part of a Building Schools for the Future Programme?
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+          No
+          </dd>
+        </div>
+      </dl>
+      <a name="grant"></a> <h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Pre-opening support grant</h2>
+      <h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Details</h3>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Do you want these funds paid to the school or the trust?
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+            To the trust the school is joining
+          </dd>
+        </div>
+      </dl>
+      <a name="consultation"></a><h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Consultation</h2>
+      <a name="declaration"></a> <h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Details</h3>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Has the governing body consulted the relevant stakeholders?
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+            No
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            When does the governing body plan to consult?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Next month
+          </dd>
+        </div>
+      </dl>
+      <h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Declaration</h2>
+      <h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Details</h3>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            I agree with all of these statements, and believe that the facts stated in this application are true
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Yes
+          </dd>
+        </div>
+      </dl>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Signed by
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Garth Brown
+          </dd>
+        </div>
+      </dl>
+      </main>
+    </div>
+  
+
+    {% endblock %}

--- a/app/views/sprint-49/form-a-mat/application-mat.html
+++ b/app/views/sprint-49/form-a-mat/application-mat.html
@@ -1,0 +1,1413 @@
+{% extends "layout.html" %}
+
+{% block beforeContent %}
+<a href="./task_list_cheltenham.html" class="govuk-back-link">Back to task list</a>
+{% endblock %}
+
+{% block content %}
+          
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+
+      <span class="govuk-caption-xl">URN 102821</span>
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
+        Stroud Primary School</h1>
+        {% if data['htb-date']%}
+        <div class="govuk-inset-text"><h4 class="govuk-heading-m">HTB date</h4>
+        <p>HTB date for this project is {{ data['htb-date']}}</p></div> 
+         {% else %} 
+         {% endif %}
+<nav class="app-sub-navigation" aria-label="sub menu">
+  <ul class="app-sub-navigation__list govuk-!-margin-top-6">
+
+    <li class="app-sub-navigation__item">
+      <a class="app-sub-navigation__link" href="task_list_stroud">Task list</a>
+    </li>
+    <li class="app-sub-navigation__item">
+      <a class="app-sub-navigation__link" aria-current="page" href="#">School application form</a>
+    </li>
+    <!-- Not MVP <li class="app-sub-navigation__item">
+      <a class="app-sub-navigation__link" href="/related/dates">Project milestones</a>
+    </li> -->
+    <li class="app-sub-navigation__item">
+      <a class="app-sub-navigation__link"  href="#">Project notes</a>
+    </li>
+    <li class="app-sub-navigation__item">
+      <a class="app-sub-navigation__link"  href="./projects-other-mat-stroud.html">Other schools in this MAT</a>
+    </li>
+</ul>
+
+</nav>
+</div>
+<div class="govuk-grid-column-full">
+
+<p><a href="application_newtab" target="application">Open school application form in a new tab</a></p>
+  <h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">School application form</h2>
+
+  <nav class="gem-c-contents-list" aria-label="Pages in this guide" role="navigation" data-module="gem-track-click"> <h2 class="gem-c-contents-list__title"> Contents</h2>
+    <ol class="gem-c-contents-list__list">
+        <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed"> <a class="gem-c-contents-list__link govuk-link"  href="#overview"> Overview</a></li> 
+        <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed"> <a class="gem-c-contents-list__link govuk-link"  href="#trust">Trust information</a></li>
+        <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed"> <a class="gem-c-contents-list__link govuk-link"  href="#about">About the conversion</a></li>
+        <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed"> <a class="gem-c-contents-list__link govuk-link"  href="#further_info">Further information</a></li>
+        <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed"> <a class="gem-c-contents-list__link govuk-link"  href="#finances">Finances</a></li>
+        <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed"> <a class="gem-c-contents-list__link govuk-link"  href="#numbers">Future pupil numbers</a></li>
+        <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed"> <a class="gem-c-contents-list__link govuk-link"  href="#land">Land and buildings</a></li>
+        <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed"> <a class="gem-c-contents-list__link govuk-link"  href="#grant">Pre-opening support grant</a></li>
+        <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed"> <a class="gem-c-contents-list__link govuk-link"  href="#consultation">Consultation</a></li>
+        <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed"> <a class="gem-c-contents-list__link govuk-link"  href="#declaration">Declaration</a></li></li>
+    </ol></nav>
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+    <a name="overview"></a><h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Overview</h2>
+        <dl class="govuk-summary-list  govuk-!-margin-top">
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Application to join
+    </dt>
+    <dd class="govuk-summary-list__value">
+      Gloucester Academy Trust with Cheltenham Spa Primary School
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Application reference
+    </dt>
+    <dd class="govuk-summary-list__value">
+      AS_100006
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Lead applicant
+    </dt>
+    <dd class="govuk-summary-list__value">
+      Bob Roberts
+    </dd>
+  </div>
+</dl>
+
+<a name="trust"></a><h2 class="govuk-heading-l govuk-!-margin-bottom-3">Trust information</h2>
+ 
+  </div>
+  <div class="govuk-grid-column-full">
+  <dl class="govuk-summary-list">
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    Proposed name of the trust
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <p class="govuk-body">Gloucestershire Academy Trust</p>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+  </dd>
+</div>
+</dl>
+
+
+<h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Opening date</h3>
+
+<dl class="govuk-summary-list">
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    When do you plan to establish the new multi-academy trust?
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <p class="govuk-body">1 September 2023</p>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+  </dd>
+</div>
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    Full name
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <p class="govuk-body">Bob Roberts</p>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+  </dd>
+</div>
+
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    Email address
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <p class="govuk-body">bob.roberts@education.gov.uk</p>
+  </dd>
+  <dd class="govuk-summary-list__actions">
+    <!--<a class="govuk-link" href="route-involuntary.html">Change<span class="govuk-visually-hidden">route"</span></a>-->
+  </dd>
+</div>
+</dl>
+
+
+
+
+
+<h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Reasons for forming the trust</h3>
+
+
+<dl class="govuk-summary-list">
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+  Why are the schools forming the trust?
+</dt>
+<dd class="govuk-summary-list__value">
+  <p class="govuk-body">Details about this here...</p>
+</dd>
+<dd class="govuk-summary-list__actions">
+</dd>
+</div>
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+  What vision and aspirations have the schools agreed to for the trust?
+</dt>
+<dd class="govuk-summary-list__value">
+  <p class="govuk-body">Vision and aspirations info here...</p>
+</dd>
+<dd class="govuk-summary-list__actions">
+</dd>
+</div>
+
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+  What geographical areas and communities will the trust serve?
+</dt>
+<dd class="govuk-summary-list__value">
+  <p class="govuk-body">Geographical information here...</p>
+</dd>
+<dd class="govuk-summary-list__actions">
+  <!--<a class="govuk-link" href="route-involuntary.html">Change<span class="govuk-visually-hidden">route"</span></a>-->
+</dd>
+</div>
+
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+  How will the schools make the most of the freedom that academies have?
+</dt>
+<dd class="govuk-summary-list__value">
+  Details about academy freedoms here...
+</dd>
+<dd class="govuk-summary-list__actions">
+  <!--<a class="govuk-link" href="set-form-7.html">Change<span class="govuk-visually-hidden">form 7 received</span></a>-->
+</dd>
+</div>
+
+
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+  How will the schools work together to improve teaching and learning
+</dt>
+<dd class="govuk-summary-list__value">
+  Information about teaching and learning here...
+</dd>
+<dd class="govuk-summary-list__actions">
+  <!--<a class="govuk-link" href="set-form-7-date.html">Change<span class="govuk-visually-hidden">form 7 received</span></a>-->
+</dd>
+</div>
+</dl>
+
+
+
+<h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Plans for growth</h3>
+
+<dl class="govuk-summary-list">
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+  Do you plan to grow the trust over the next 5 years?
+</dt>
+<dd class="govuk-summary-list__value">
+  <p class="govuk-body">Yes</p>
+</dd>
+<dd class="govuk-summary-list__actions">
+</dd>
+</div>
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+  What are your plans?
+</dt>
+<dd class="govuk-summary-list__value">
+  <p class="govuk-body">Details of how to grow the trust here...</p>
+</dd>
+<dd class="govuk-summary-list__actions">
+</dd>
+</div>
+
+<!--
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+  Why are you not planning to grow?
+</dt>
+<dd class="govuk-summary-list__value">
+  <p class="govuk-body">Reasons why no plans to grow here...</p>
+</dd>
+<dd class="govuk-summary-list__actions">
+  <a class="govuk-link" href="route-involuntary.html">
+    Change<span class="govuk-visually-hidden">route"</span>
+  </a>
+</dd>
+</div>
+-->
+
+</dl>
+
+
+<h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">School improvement strategy</h3>
+
+
+<dl class="govuk-summary-list">
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+  How will the trust support and improve the academies in the trust?
+</dt>
+<dd class="govuk-summary-list__value">
+  <p class="govuk-body">Details here...</p>
+</dd>
+<dd class="govuk-summary-list__actions">
+</dd>
+</div>
+
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+  How will the trust make sure that the school improvement strategy is fit for purpose and improve standards?
+</dt>
+<dd class="govuk-summary-list__value">
+  <p class="govuk-body">Details here...</p>
+</dd>
+<dd class="govuk-summary-list__actions">
+</dd>
+</div>
+
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+  If the trust wants to become an approved sponsor, when would it plan to apply and begin sponsoring schools?
+</dt>
+<dd class="govuk-summary-list__value">
+  <p class="govuk-body">Details here...</p>
+</dd>
+<dd class="govuk-summary-list__actions">
+  <!--<a class="govuk-link" href="route-involuntary.html">Change<span class="govuk-visually-hidden">route"</span></a>-->
+</dd>
+</div>
+</dl>
+
+
+
+<h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Governence structure</h3>
+
+
+<dl class="govuk-summary-list">
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+  Row one label
+</dt>
+<dd class="govuk-summary-list__value">
+  <p class="govuk-body">Row one details</p>
+</dd>
+<dd class="govuk-summary-list__actions">
+</dd>
+</div>
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+  Row two label
+</dt>
+<dd class="govuk-summary-list__value">
+  <p class="govuk-body">Row two details</p>
+</dd>
+<dd class="govuk-summary-list__actions">
+</dd>
+</div>
+
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+  Row three label
+</dt>
+<dd class="govuk-summary-list__value">
+  <p class="govuk-body">Row three label</p>
+</dd>
+<dd class="govuk-summary-list__actions">
+  <!--<a class="govuk-link" href="route-involuntary.html">Change<span class="govuk-visually-hidden">route"</span></a>-->
+</dd>
+</div>
+</dl>
+
+
+
+<h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Key people</h3>
+
+<dl class="govuk-summary-list">
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+  Row one label
+</dt>
+<dd class="govuk-summary-list__value">
+  <p class="govuk-body">Row one details</p>
+</dd>
+<dd class="govuk-summary-list__actions">
+</dd>
+</div>
+
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+  Row two label
+</dt>
+<dd class="govuk-summary-list__value">
+  <p class="govuk-body">Row two details</p>
+</dd>
+<dd class="govuk-summary-list__actions">
+</dd>
+</div>
+
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+  Row three label
+</dt>
+<dd class="govuk-summary-list__value">
+  <p class="govuk-body">Row three label</p>
+</dd>
+<dd class="govuk-summary-list__actions">
+  <!--<a class="govuk-link" href="route-involuntary.html">Change<span class="govuk-visually-hidden">route"</span></a>-->
+</dd>
+</div>
+</dl>
+
+<a name="about"></a><h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">About the conversion</h2>
+<h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">The school joining the trust</h3>
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      The name of the school
+    </dt>
+    <dd class="govuk-summary-list__value">
+      Cheltenham Spa Primary School
+    </dd>
+  </div>
+</dl>
+
+  <h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Contact details</h3>
+  <dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Name of headteacher
+    </dt>
+    <dd class="govuk-summary-list__value">
+     Garth Brown
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Headteacher's email address
+    </dt>
+    <dd class="govuk-summary-list__value">
+      garth.brown@cheltenhamspaprimary.edu.uk
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Headteacher's phone number
+    </dt>
+    <dd class="govuk-summary-list__value">
+     0987 664 547
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Name of the chair of the Governing Body
+    </dt>
+    <dd class="govuk-summary-list__value">
+      Arna Siggurdottier
+    </dd>
+  </div>
+<div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Chair's email address
+    </dt>
+    <dd class="govuk-summary-list__value">
+     arna.siggurdottier@gloucesteracademytrust.co.uk
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Chair's phone number
+    </dt>
+    <dd class="govuk-summary-list__value">
+     0972 345 119
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Who is the main contact for the conversion?
+    </dt>
+    <dd class="govuk-summary-list__value">
+     Someone else
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Name of main contact
+    </dt>
+    <dd class="govuk-summary-list__value">
+     Carol Berry
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Main contact's email address
+    </dt>
+    <dd class="govuk-summary-list__value">
+     carol.b@gmail.com
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Main contact's phone number
+    </dt>
+    <dd class="govuk-summary-list__value">
+     0759 312 344
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Main contact's role
+    </dt>
+    <dd class="govuk-summary-list__value">
+     Trust CEO
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Approver's name
+    </dt>
+    <dd class="govuk-summary-list__value">
+     Garth Brown
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Approver's email address
+    </dt>
+    <dd class="govuk-summary-list__value">
+    garth.brown@cheltenhamspaprimary.edu.uk
+    </dd>
+  </div>
+</dl>
+
+
+<h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Date for conversion</h3>
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Do you want the conversion to happen on a particular date
+    </dt>
+    <dd class="govuk-summary-list__value">
+      Yes
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Preferred date
+    </dt>
+    <dd class="govuk-summary-list__value">
+     01/11/2021
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Explain why you want to convert on this date
+    </dt>
+    <dd class="govuk-summary-list__value">
+     It is in line with the start of the school term meaning there will be less disruption for students.
+    </dd>
+  </div>
+</dl>
+
+<h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Reasons for joining</h3>
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Why does the school want to join this trust in particular?
+    </dt>
+    <dd class="govuk-summary-list__value">
+     <p>The Diocesan Academy Policy (December 2019) states the expectation that all schools within the Diocese of Warrington will convert to academy status within one of the four Diocesan Catholic Education Trusts by July 2022. The resulting growth plan earmarks our school for transition into Dynamics Trust. This Catholic trust model ensures every school has its place and no individual school is left isolated or vulnerable, in a rapidly changing environment. It also ensures that the uniqueness of each individual school is celebrated and the unique contribution of each is recognised and appreciated. The Trust has an experienced Director of Learning and Teaching who effectively co-ordinates some central school effectiveness provision to monitor school performance/ achievement and ensures support is provided and matched to need, mainly as brokerage, within the system leadership structure.</p><p>The Trust’s school improvement model is based on the new Northern Alliance, aiming to build capacity and improve educational standards in the North of England. In the words of Sir David Carter “the Northern Alliance is an innovative partnership which illustrates the strength of collaboration that is emerging as part of our developing self-improving school system.” Through the excellent, collaborative work delivered to date and first-hand experience of supporting other schools/academies across the North West, the expanding Trust has the expertise to ensure that each partner school can benefit, as a robust infrastructure to support future growth is built. Careful monitoring of each school by the CEO, School Improvement Partner, Headteachers and Trust Board ensures that high quality teaching takes place across the Trust. There is currently excellent practice demonstrated within the Primary and Secondary partners within the existing Dynamics Trust.</p>   
+    </dd>
+  </div></dl>
+
+  <h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Name changes</h3>
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Is the school planning to change its name when it becomes an academy?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Yes
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        What's the proposed new name?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Cheltenham Spa Academy
+      </dd>
+    </div>
+  </dl>
+
+
+  <a name="further_info"></a> <h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Further information</h2>
+  <h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Additional details</h3>
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        What will the school bring to the trust they are joining?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Our school’s highly motivated team will contribute to the expansion of the range of expertise at primary level in the Trust and our success can be demonstrated through the high quality care and teaching that is delivered at St Wilfrid's Primary School. As reported by OFSTED in 2017, the good quality of education was maintained since the previous OFSTED inspection and it was also reported that there is a determination that academic standards continue to improve, complimenting the Trust’s aim to offer outstanding education provision to all children. Our school is committed to knowing all our pupils, their families and their needs which can be illustrated in the improvement in attendance where the close working relationship with parents and carers was considered by inspectors to be a contributing factor. This supports the Trust’s value of close working and supportive relationships with its parents and carers. Working closely with St Mary’s Catholic School and Sixth Form, the Trust school which our students feed in to, community links and relationships will be developed and strengthened as a result of our School joining the Trust.</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Have Ofsted recently inspected the school but not published the report yet?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Yes</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Provide the inspection date and short summary of the outcome
+      </dt>
+      <dd class="govuk-summary-list__value">
+        12/11/2021. The outcome was that Ofsted were impressed with the progress made by the school to improve behaviour of the students.</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Are there any safeguarding investigations ongoing at the school?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Yes</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Details of the investigation
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Some explanation here.</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Is the school part of a local authority reorganisation?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Yes</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Details of the reorganisation
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Some explanation here.</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Is the school part of any local authority closure plans?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Yes</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Details of the closure plan
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Some explanation here.</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Is your school linked to a diocese?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Yes</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Name of diocese?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Diocese of Gloucestershire</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+       Upload a letter of consent from the diocese
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <a href="#">constent-from-diocese.docx</a></dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Is your school part of a federation?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        No</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Is the school supported by a foundation, trust or other body (e.g. parish council) that appoints foundation governors?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Yes</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Name of this body
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Joe Bloggs Foundation</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Upload their letter of consent
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <a href="#">constent-from-foundation.docx</a></dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Does the school currently have an exemption from providing broadly Christian collective worship issued by the local Standing Committee on Religious Education (SACRE)?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Yes</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        When does the exemption end?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        4/5/2023</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Please provide a list of your main feeder schools
+      </dt>
+      <dd class="govuk-summary-list__value">
+        St Mary's Catholic School, St Catherine's Nursery School</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        The school's Governing Body must have passed a resolution to apply to convert to academy status. Upload a copy of the school’s consent to converting and joining the trust.
+      </dt>
+      <dd class="govuk-summary-list__value">
+      <a href="#"> consent.docx</a></dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+      Has an equalities impact assessment been carried out and considered by the governing body?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Yes</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        When the governing body considered the equality duty what did they decide?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        That the Secretary of State's decision is unlikely to disproportionately affect any particular person or group who share protected charateristics.</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Do you want to add any further information?</dt>
+      <dd class="govuk-summary-list__value">
+      Yes</dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Add any further information</dt>
+      <dd class="govuk-summary-list__value">
+      Some further information.</dd>
+    </div>
+  </dl>
+
+
+  <a name="finances"></a> <h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Finances</h2>
+  <h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Previous financial year</h3>
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        End of previous financial year
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        31/03/2021
+      </dd>
+    </div>
+  </dl>
+
+
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+      Revenue carry forward at the end of the previous financial year (31 March)
+    </dt>
+    <dd class="govuk-summary-list__value">
+      - £169,093.00
+    </dd>
+  </div>
+</dl>
+
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+      Surplus or deficit?
+    </dt>
+    <dd class="govuk-summary-list__value">
+      Deficit
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+    Explain the reasons for the deficit, how the school plans to deal with it, and the recovery plan
+  </dt>
+  <dd class="govuk-summary-list__value">
+    Some explanation here.
+  </dd>
+</div>
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+  Upload the school's recovery plan
+</dt>
+<dd class="govuk-summary-list__value">
+  No upload provided
+</dd>
+</div>
+</dl>
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+  </div>
+</dl>
+
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+    Capital carry forward at the end of the previous financial year (31 March)
+  </dt>
+  <dd class="govuk-summary-list__value">
+    - £20,000.00
+  </dd>
+</div>
+</dl>
+
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+    Surplus or deficit?
+  </dt>
+  <dd class="govuk-summary-list__value">
+    Deficit
+  </dd>
+</div>
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+  Explain the reasons for the deficit, how the school plans to deal with it, and the recovery plan
+</dt>
+<dd class="govuk-summary-list__value">
+  Some explanation here.
+</dd>
+</div>
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+Upload the school's recovery plan
+</dt>
+<dd class="govuk-summary-list__value">
+No upload provided
+</dd>
+</div>
+</dl>
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+</div>
+</dl>
+
+<h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Current financial year</h3>
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        End of current financial year
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        31/03/2022
+      </dd>
+    </div>
+  </dl>
+
+
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+      Forecasted revenue carry forward at the end of the current financial year (31 March)
+    </dt>
+    <dd class="govuk-summary-list__value">
+      - £10.00
+    </dd>
+  </div>
+</dl>
+
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+      Surplus or deficit?
+    </dt>
+    <dd class="govuk-summary-list__value">
+      Deficit
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+    Explain the reasons for the deficit, how the school plans to deal with it, and the recovery plan
+  </dt>
+  <dd class="govuk-summary-list__value">
+    Some explanation here.
+  </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+  Upload the school's recovery plan
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <a href="#"> recovery-plan.docx</a>
+  </dd>
+  </div>
+  </dl>
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+  </div>
+</dl>
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+    Forecasted capital carry forward at the end of the current financial year (31 March)
+  </dt>
+  <dd class="govuk-summary-list__value">
+    - £20.00
+  </dd>
+</div>
+</dl>
+
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+    Surplus or deficit?
+  </dt>
+  <dd class="govuk-summary-list__value">
+    Deficit
+  </dd>
+</div>
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+  Explain the reasons for the deficit, how the school plans to deal with it, and the recovery plan
+</dt>
+<dd class="govuk-summary-list__value">
+  Some explanation here.
+</dd>
+</div>
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+Upload the school's recovery plan
+</dt>
+<dd class="govuk-summary-list__value">
+  <a href="#">recovery-plan.docx</a>
+</dd>
+</div>
+</dl>
+<h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Next financial year</h3>
+<dl class="govuk-summary-list">
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    End of current financial year
+
+  </dt>
+  <dd class="govuk-summary-list__value">
+    31/03/2022
+  </dd>
+</div>
+</dl>
+
+
+<dl class="govuk-summary-list">
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+  Forecasted revenue carry forward at the end of the next financial year (31 March)
+</dt>
+<dd class="govuk-summary-list__value">
+  - £143,931.00
+</dd>
+</div>
+</dl>
+
+<dl class="govuk-summary-list">
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+  Surplus or deficit?
+</dt>
+<dd class="govuk-summary-list__value">
+  Deficit
+</dd>
+</div>
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+  Explain the reasons for the deficit, how the school plans to deal with it, and the recovery plan
+</dt>
+<dd class="govuk-summary-list__value">
+  Some explanation here.
+</dd>
+</div>
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+Upload the school's recovery plan
+</dt>
+<dd class="govuk-summary-list__value">
+  <a href="#">recovery-plan.docx</a>
+</dd>
+</div>
+</dl>
+<dl class="govuk-summary-list">
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+Forecasted capital carry forward at the end of the next financial year (31 March)
+</dt>
+<dd class="govuk-summary-list__value">
+- £30,345.00
+</dd>
+</div>
+</dl>
+
+<dl class="govuk-summary-list">
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+Surplus or deficit?
+</dt>
+<dd class="govuk-summary-list__value">
+Deficit
+</dd>
+</div>
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+  Explain the reasons for the deficit, how the school plans to deal with it, and the recovery plan
+</dt>
+<dd class="govuk-summary-list__value">
+  Some explanation here.
+</dd>
+</div>
+<div class="govuk-summary-list__row">
+<dt class="govuk-summary-list__key">
+Upload the school's recovery plan
+</dt>
+<dd class="govuk-summary-list__value">
+  <a href="#">recovery-plan.docx</a>
+</dd>
+</div>
+</dl>
+<h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Loans</h3>
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Are there any exisiting loans?
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Yes
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Total amount
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        £3000.00
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Purpose of the loan
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Some explanation here.
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Loan provider
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        ABC Loan Provider
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Interest rate
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        2%
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Schedule of repayment
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        £200 per month
+      </dd>
+    </div>
+  </dl>
+  <h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Financial leases</h3>
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Are there any exisiting leases?
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Yes
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Details of the term of the finance lease agreement
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Some explanation here.
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Repayment value
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        £10,000.00
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Interest rate chargable
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        5%
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Value of payments made to date
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        £2000.00
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        What was the finance lease for?
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        To pay for IT equipment
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Value of the assests at the start of the finance lease agreement
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        £5000.00
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Who is responsible for the insurance, repair and maintenance of the assets covered?
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        The IT specialists at the school.
+      </dd>
+    </div>
+  </dl>
+
+  <h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Financial investigations</h3>
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Are there any financial investigations ongoing at the school?
+
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Yes
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Provide a bried summary of the investigation
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Some explanation here.
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Is the trust you are joining aware of the investigation
+      </dt>
+      <dd class="govuk-summary-list__value">
+        Yes
+      </dd>
+    </div>
+  </dl>
+
+
+  <a name="numbers"></a> <h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Future pupil numbers</h2>
+      <h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Details</h3>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Projected pupil numbers on roll in the year the academy opens (year 1)
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+            189
+          </dd>
+        </div>
+      </dl>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Projected pupil numbers on roll in the following year after the academy has opened (year 2)
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+            189
+          </dd>
+        </div>
+      </dl>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Projected pupil numbers on roll in the following year (year 3)
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+            189
+          </dd>
+        </div>
+      </dl>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            What do you base these projected numbers on?
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+            We expect 30 pupils intake each year in Reception. This is typical for our school but we predict a decrease in future due to a few nursery schools in the area closing. By joining Dynamics Trust, we expect we will have more opportunity to encourage more pupils to the school. The trust's track record of improving pupil intake is one of the reasons we want to join this trust and explains the increase we predict.
+          </dd>
+        </div>
+      </dl>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            What is the school's published admissions number (PAN)?
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+          210
+          </dd>
+        </div>
+      </dl>
+
+      <a name="land"></a><h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Land and buildings</h2>
+      <h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Details</h3>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            As far as you're aware, who owns or holds the school's buildings and land?
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+            The Diocese of Warrington owns the building and the land. The LA owns the playing fields.
+          </dd>
+        </div>
+      </dl>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Are there any current planned building works?
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Yes
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Provide details of the works, how they'll be funded and whether the funding will be affected by the conversion
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Some explanation here.
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            When is the scheduled completion date
+          </dt>
+          <dd class="govuk-summary-list__value">
+            19/1/2022
+          </dd>
+        </div>
+      </dl>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Are there any shared facilities on site?
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Yes
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            List the facilities and the school's plan for them after converting
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Some explanation here.
+          </dd>
+        </div>
+      </dl>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Has the school had any grants from Sport England, the Big Lottery Fund, or the Football Federation?
+          </dt>
+          <dd class="govuk-summary-list__value">
+          Yes
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Which bodies awarded the grants and what facilities did they fund?
+          </dt>
+          <dd class="govuk-summary-list__value">
+          Some explanation here.
+          </dd>
+        </div>
+      </dl>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+          Is the school part of a Private Finance Intiative (PFI) scheme?
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+          Yes
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            What kind of PFI Scheme is your school part of?
+          </dt>
+          <dd class="govuk-summary-list__value">
+          Some explanation here.
+          </dd>
+        </div>
+      </dl>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+          Is the school part of a Priority School Building Programme?
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+          No
+          </dd>
+        </div>
+      </dl>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+          Is the school part of a Building Schools for the Future Programme?
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+          No
+          </dd>
+        </div>
+      </dl>
+      <a name="grant"></a> <h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Pre-opening support grant</h2>
+      <h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Details</h3>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Do you want these funds paid to the school or the trust?
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+            To the trust the school is joining
+          </dd>
+        </div>
+      </dl>
+      <a name="consultation"></a><h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Consultation</h2>
+      <a name="declaration"></a> <h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Details</h3>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Has the governing body consulted the relevant stakeholders?
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+            No
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            When does the governing body plan to consult?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Next month
+          </dd>
+        </div>
+      </dl>
+      <h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Declaration</h2>
+      <h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">Details</h3>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            I agree with all of these statements, and believe that the facts stated in this application are true
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Yes
+          </dd>
+        </div>
+      </dl>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Signed by
+  
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Garth Brown
+          </dd>
+        </div>
+      </dl>
+      </main>
+    </div>
+  
+
+    {% endblock %}

--- a/app/views/sprint-49/form-a-mat/projects-list-involuntary-conversions-alt.html
+++ b/app/views/sprint-49/form-a-mat/projects-list-involuntary-conversions-alt.html
@@ -282,7 +282,7 @@
           </tr>
 
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell"><h2 class="govuk-caption-l govuk-!-margin-bottom-0 govuk-!-margin-top-1"><strong><a href="task_list_gloucester">Gloucester Primary School</a></strong> URN 100006</h2>
+            <td class="govuk-table__cell"><h2 class="govuk-caption-l govuk-!-margin-bottom-0 govuk-!-margin-top-1"><strong><a href="task_list_gloucester">Gloucester Primary School</a></strong> URN 101573</h2>
               <p class="govuk-!-margin-top-3">
               Route: Form a MAT</br>
               Application to join a trust: Gloucestershire Academy Trust</br>
@@ -303,7 +303,7 @@
           </tr>
 
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell"><h2 class="govuk-caption-l govuk-!-margin-bottom-0 govuk-!-margin-top-1"><strong><a href="task_list_involuntary_conversions">Stroud Primary School</a></strong> URN 100006</h2>
+            <td class="govuk-table__cell"><h2 class="govuk-caption-l govuk-!-margin-bottom-0 govuk-!-margin-top-1"><strong><a href="task_list_stroud">Stroud Primary School</a></strong> URN 100821</h2>
               <p class="govuk-!-margin-top-3">
               Route: Form a MAT</br>
               Application to join a trust: Gloucestershire Academy Trust</br>
@@ -324,7 +324,7 @@
           </tr>
 
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell"><h2 class="govuk-caption-l govuk-!-margin-bottom-0 govuk-!-margin-top-1"><strong><a href="task_list_involuntary_conversions">Prestbury Primary School</a></strong> URN 100006</h2>
+            <td class="govuk-table__cell"><h2 class="govuk-caption-l govuk-!-margin-bottom-0 govuk-!-margin-top-1"><strong><a href="#">Prestbury Primary School</a></strong> URN 103459</h2>
               <p class="govuk-!-margin-top-3">
               Route: Form a MAT</br>
               Application to join a trust: Gloucestershire Academy Trust</br>
@@ -345,7 +345,7 @@
           </tr>
 
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell"><h2 class="govuk-caption-l govuk-!-margin-bottom-0 govuk-!-margin-top-1"><strong><a href="task_list_involuntary_conversions">Winchcombe Primary School</a></strong> URN 100006</h2>
+            <td class="govuk-table__cell"><h2 class="govuk-caption-l govuk-!-margin-bottom-0 govuk-!-margin-top-1"><strong><a href="#">Winchcombe Primary School</a></strong> URN 104944</h2>
               <p class="govuk-!-margin-top-3">
               Route: Form a MAT</br>
               Application to join a trust: Gloucestershire Academy Trust</br>

--- a/app/views/sprint-49/form-a-mat/projects-other-mat-glos.html
+++ b/app/views/sprint-49/form-a-mat/projects-other-mat-glos.html
@@ -314,13 +314,13 @@
               <a class="app-sub-navigation__link"  href="./task_list_gloucester.html">Task list</a>
             </li>
             <li class="app-sub-navigation__item">
-              <a class="app-sub-navigation__link"  href="related/application_saved_involuntary_conversions.html">School application form</a>
+              <a class="app-sub-navigation__link"  href="related/application-glos.html">School application form</a>
             </li>
             <!-- Not MVP <li class="app-sub-navigation__item">
               <a class="app-sub-navigation__link" href="/related/dates">Project milestones</a>
             </li> -->
             <li class="app-sub-navigation__item">
-              <a class="app-sub-navigation__link"  href="related/notes_involuntary_conversions.html">Project notes</a>
+              <a class="app-sub-navigation__link"  href="#">Project notes</a>
             </li>
             <li class="app-sub-navigation__item">
               <a class="app-sub-navigation__link" href="./trust-information-alt.html">Trust information</a>
@@ -373,7 +373,7 @@
           </tr>
 
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell"><h2 class="govuk-caption-l govuk-!-margin-bottom-0 govuk-!-margin-top-1"><strong><a href="#">Stroud Primary School</a></strong> URN 102821</h2>
+            <td class="govuk-table__cell"><h2 class="govuk-caption-l govuk-!-margin-bottom-0 govuk-!-margin-top-1"><strong><a href="task_list_stroud.html">Stroud Primary School</a></strong> URN 102821</h2>
               <p class="govuk-!-margin-top-3">
               Route: Form a MAT</br>
               Application to join a trust: Gloucestershire Academy Trust</br>

--- a/app/views/sprint-49/form-a-mat/projects-other-mat-stroud.html
+++ b/app/views/sprint-49/form-a-mat/projects-other-mat-stroud.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Cheltenham Spa Primary School - task list
+  Sroud Primary School - task list
 {% endblock %}
 
 {% block beforeContent %}
@@ -41,9 +41,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <span class="govuk-caption-xl govuk-!-margin-top-6" >URN 100006</span>
+    <span class="govuk-caption-xl govuk-!-margin-top-6" >URN 102821</span>
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
-      Cheltenham Spa Primary School 
+      Stroud Primary School 
     </h1>
     <p class="govuk-body govuk-!-margin-bottom-8">
       Route: Form a MAT</br>
@@ -311,10 +311,10 @@
       <ul class="app-sub-navigation__list govuk-!-margin-top-6">
 
             <li class="app-sub-navigation__item">
-              <a class="app-sub-navigation__link"  href="./task_list_cheltenham.html">Task list</a>
+              <a class="app-sub-navigation__link"  href="./task_list_stroud.html">Task list</a>
             </li>
             <li class="app-sub-navigation__item">
-              <a class="app-sub-navigation__link"  href="application">School application form</a>
+              <a class="app-sub-navigation__link"  href="./application-mat.html">School application form</a>
             </li>
             <!-- Not MVP <li class="app-sub-navigation__item">
               <a class="app-sub-navigation__link" href="/related/dates">Project milestones</a>
@@ -323,10 +323,7 @@
               <a class="app-sub-navigation__link"  href="#">Project notes</a>
             </li>
             <li class="app-sub-navigation__item">
-              <a class="app-sub-navigation__link" href="./trust-information.html">Trust information</a>
-            </li>
-            <li class="app-sub-navigation__item">
-              <a class="app-sub-navigation__link" aria-current="page" href="./other_mat_schools.html">Other schools in this MAT</a>
+              <a class="app-sub-navigation__link" aria-current="page" href="#">Other schools in this MAT</a>
             </li>
       </ul>
 
@@ -352,7 +349,7 @@
        
 
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell"><h2 class="govuk-caption-l govuk-!-margin-bottom-0 govuk-!-margin-top-1"><strong><a href="task_list_gloucester">Gloucester Primary School</a></strong> URN 101573</h2>
+            <td class="govuk-table__cell"><h2 class="govuk-caption-l govuk-!-margin-bottom-0 govuk-!-margin-top-1"><strong><a href="task_list_cheltenham">Cheltenham Spa Primary School</a></strong> URN 100006</h2>
               <p class="govuk-!-margin-top-3">
               Route: Form a MAT</br>
               Application to join a trust: Gloucestershire Academy Trust</br>
@@ -373,7 +370,7 @@
           </tr>
 
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell"><h2 class="govuk-caption-l govuk-!-margin-bottom-0 govuk-!-margin-top-1"><strong><a href="task_list_stroud.html">Stroud Primary School</a></strong> URN 102821</h2>
+            <td class="govuk-table__cell"><h2 class="govuk-caption-l govuk-!-margin-bottom-0 govuk-!-margin-top-1"><strong><a href="task_list_gloucester">Gloucester Primary School</a></strong> URN 101573</h2>
               <p class="govuk-!-margin-top-3">
               Route: Form a MAT</br>
               Application to join a trust: Gloucestershire Academy Trust</br>

--- a/app/views/sprint-49/form-a-mat/task_list_stroud.html
+++ b/app/views/sprint-49/form-a-mat/task_list_stroud.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Cheltenham Spa Primary School - task list
+  Stroud Primary School - task list
 {% endblock %}
 
 {% block beforeContent %}
@@ -41,9 +41,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <span class="govuk-caption-xl govuk-!-margin-top-6" >URN 100006</span>
+    <span class="govuk-caption-xl govuk-!-margin-top-6" >URN 102821</span>
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
-      Cheltenham Spa Primary School 
+      Stroud Primary School 
     </h1>
     <p class="govuk-body govuk-!-margin-bottom-8">
       Route: Form a MAT</br>
@@ -311,10 +311,10 @@
       <ul class="app-sub-navigation__list govuk-!-margin-top-6">
 
             <li class="app-sub-navigation__item">
-              <a class="app-sub-navigation__link"  href="./task_list_cheltenham.html">Task list</a>
+              <a class="app-sub-navigation__link" aria-current="page" href="task_list">Task list</a>
             </li>
             <li class="app-sub-navigation__item">
-              <a class="app-sub-navigation__link"  href="application">School application form</a>
+              <a class="app-sub-navigation__link"  href="./application-mat.html">School application form</a>
             </li>
             <!-- Not MVP <li class="app-sub-navigation__item">
               <a class="app-sub-navigation__link" href="/related/dates">Project milestones</a>
@@ -323,119 +323,226 @@
               <a class="app-sub-navigation__link"  href="#">Project notes</a>
             </li>
             <li class="app-sub-navigation__item">
-              <a class="app-sub-navigation__link" href="./trust-information.html">Trust information</a>
-            </li>
-            <li class="app-sub-navigation__item">
-              <a class="app-sub-navigation__link" aria-current="page" href="./other_mat_schools.html">Other schools in this MAT</a>
+              <a class="app-sub-navigation__link"  href="./projects-other-mat-stroud.html">Other schools in this MAT</a>
             </li>
       </ul>
 
     </nav>
   </div>
 
-  <div class="govuk-grid-column-full">
-    <table class="govuk-table">
-      <caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden">Projects (12)</caption>
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th class="govuk-table__header app-!-width-three-fifths">
-            Application information
-          </th>
-          <th class="govuk-table__header prepare-text-align-right app-!-width-two-fifths">
-            Project status and dates
-          </th>  
-        </tr>
-      </thead>
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l govuk-!-margin-bottom-3">Task list</h2>
+    <p class="govuk-body">The task list will help you prepare for the Advisory Board meeting (formally headteacher board). You can complete the tasks in any order.</p>
+  
+    <ul class="app-task-list">
+      <li>
+        <h3 class="app-task-list__section govuk-!-margin-top-8">Local authority (LA) information template</h3>
+        <ul class="app-task-list__items govuk-!-padding-left-0">
+          <li class="app-task-list__item">
+            <span class="app-task-list__task-name">
+              <a 
+                href="{{data|laProformaNextPageLink(
+                      ['overview-status'],
+                      ['la-sent-date-day', la-sent-date-month', la-sent-date-year', 
+                      'la-sent-back-day', 'la-sent-back-month', 'la-sent-back-year', 
+                      'la-comments', 'la-sharepoint-link']                
+                    )}}" 
+                aria-describedby="LA-infromation-template-involuntary">
+                Record dates for the LA information template 
+              </a>
+            </span>
+            <strong class="{{data|laProformaStatusClass(
+                      ['la-proforma-status'],
+                      ['la-sent-date-day', la-sent-date-month', la-sent-date-year', 
+                      'la-sent-back-day', 'la-sent-back-month', 'la-sent-back-year', 
+                      'la-comments', 'la-sharepoint-link']  
+              )}} app-task-list__tag" id="LA-infromation-template">  
+              {{data|laProformaStatusText(
+                ['la-proforma-status'],
+                ['la-sent-date-day', la-sent-date-month', la-sent-date-year', 
+                'la-sent-back-day', 'la-sent-back-month', 'la-sent-back-year', 
+                'la-comments', 'la-sharepoint-link']               
+              )}} 
+            </strong>            
+          </li>
+        </ul>
+      </li>
 
-      <tbody class="govuk-table__body">
+      <li>
+        <h3 class="app-task-list__section govuk-!-margin-top-0">Sponsor template guidance</h3>
+        <ul class="app-task-list__items govuk-!-padding-left-0">
+          <li class="app-task-list__item">
+            <span class="app-task-list__task-name">
+              <a href="sponsor-template/index.html"  aria-describedby="trust-template">
+          Prepare your sponsor template
+              </a>
+            </span>
+            <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="school-performance">Reference only</strong>
+          </li>
+        </ul>
+      </li>
 
-       
+      <li>
+        <h3 class="app-task-list__section govuk-!-margin-top-0">Create project template</h3>
+        <ul class="app-task-list__items govuk-!-padding-left-0">
+          <li class="app-task-list__item">
+            <span class="app-task-list__task-name">
+              <a href="overview/summary1-involuntary.html"  aria-describedby="project-overview">
+                School and trust information and project dates
+              </a>
+            </span>
+            <strong class="{{data|conversionOverviewStatusClass(['overview-status'],['htb-date', 'recomendation'],['opening-date', 'aorequired'] )}} app-task-list__tag" id="project-overview">  
+                {{data|conversionOverviewStatusText(
+                  ['overview-status'],
+                  ['htb-date','recomendation'],
+                  ['opening-date', 'aorequired']
+                )}} 
+            </strong>
+          </li>
+          <li class="app-task-list__item">
+            <span class="app-task-list__task-name">
+              <a href="general-info/summary1-involuntary" aria-describedby="general-information">
+                General information
+              </a>
+            </span>
+            <strong class="{{data|generalInfoStatusClass(['general-info-status'], ['distance'], ['deficit'],['diocesan'], ['goodschools','viability'] )}} app-task-list__tag" id="general-information">  
+              {{data|generalInfoStatusText(
+                ['general-info-status'],
+                ['distance'],
+                ['deficit'],
+                ['diocesan'],
+                ['goodschools','viability' ]
+              )}} 
+            </strong>
+          </li>
+          <li class="app-task-list__item">
+            <span class="app-task-list__task-name">
+              <a href="school-performance/ofsted-comments-involuntary.html" aria-describedby="school-performance">
+                School performance (Ofsted information)
+              </a>
+            </span>
+            <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="school-performance">
+              Reference only
+            </strong>
+          </li>
+          <li class="app-task-list__item">
+            <span class="app-task-list__task-name">
+              <a href="rationale/rationale-summary1-involuntary.html" aria-describedby="rationale-status">
+                Rationale
+              </a>
+            </span>
+            <strong class="{{data|rationaleStatusClass(['rationale-status-htb'],['trust-rationale'], ['project-rationale'] )}} app-task-list__tag" id="rationale-status">  
+              {{data|rationaleOverviewStatusText(
+                ['rationale-status-htb'],
+                ['trust-rationale'],
+                ['project-rationale']
+              )}} 
+            </strong>
+          </li>
+          <li class="app-task-list__item">
+            <span class="app-task-list__task-name">
+              <a href="risks-and-issues/risks-summary1-involuntary">
+                Risks and issues
+              </a>
+            </span>
+            <strong class="{{data|riskStatusClass(['risks-status'],['risks'] )}} app-task-list__tag" id="risks-status">  
+              {{data|riskStatusText(
+                ['risks-status'],
+                ['risks']
+              )}} 
+              </strong>
+          </li>
+          <!--
+          <li class="app-task-list__item">
+            <span class="app-task-list__task-name">
+              <a href="legal-requirements/legal-summary1-involuntary.html">
+                Legal requirements
+              </a>
+            </span>
+            <strong class="{{data|legalStatusClass(['legal-status'],['legal-governing-body-checked'],['legal-consultation-checked'],['legal-diocesan-consent-checked'],['legal-foundation-consent-checked'] )}} app-task-list__tag" id="legal-status">  
+              {{data|legalStatusText(
+                ['legal-status'],
+                ['legal-governing-body-checked'],
+                ['legal-consultation-checked'],
+                ['legal-diocesan-consent-checked'],
+                ['legal-foundation-consent-checked']
+              )}} 
+            </strong>
+          </li>
+          -->
+          <li class="app-task-list__item">
+            <span class="app-task-list__task-name">
+              <a href="school-budget/budget-information2-involuntary.html" aria-describedby="school-budget-information">
+                School budget information
+              </a>
+            </span>
+            <strong class="{{data|schoolBudgetInfoStatusClass(['school-budget-status'],
+                ['finance-current-year-2021', 'finance-following-year-2022', 'finance-forward-2021', 'finance-forward-2022'] )}} 
+                app-task-list__tag" 
+                id="school-budget-informatiion">
+              {{data|schoolBudgetInfoStatusText(
+                ['school-budget-status'],
+                ['finance-current-year-2021', 'finance-following-year-2022', 'finance-forward-2021', 'finance-forward-2022']
+              )}} 
+            </strong>
+          </li>
+          <li class="app-task-list__item">
+            <span class="app-task-list__task-name">
+              <a 
+              href="pupil-forecasts/school-pupil-forecasts-summary-involuntary" 
+              aria-describedby="school-pupil-forecast">
+              School pupil forecasts
+            </a>
+            </span>
+            <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="school-pupil-forecast">
+              Reference only
+            </strong>
+          </li>
+          <li class="app-task-list__item">
+            <span class="app-task-list__task-name">
+              <a href="key-stage/key-stage-performance-comments-involuntary.html" aria-describedby="key-stage-performance-tables">
+                Key stage 2 performance tables
+              </a>
+            </span>
+            <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="performance-tables">
+              Reference only
+            </strong>
+          </li>
+          <li class="app-task-list__item">
+            <span class="app-task-list__task-name">
+              <a href="key-stage/key-stage-4-performance-comments-involuntary.html" aria-describedby="key-stage-4-performance-tables">
+                Key stage 4 performance tables
+              </a>
+            </span>
+            <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="performance-tables">
+              Reference only
+            </strong>
+          </li>
+          <li class="app-task-list__item">
+            <span class="app-task-list__task-name">
+              <a href="key-stage/key-stage-5-performance-comments-involuntary.html" aria-describedby="key-stage-4-performance-tables">
+                Key stage 5 performance tables
+              </a>
+            </span>
+            <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="performance-tables">
+              Reference only
+            </strong>
+          </li>
+        </ul>
+      </li>
 
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell"><h2 class="govuk-caption-l govuk-!-margin-bottom-0 govuk-!-margin-top-1"><strong><a href="task_list_gloucester">Gloucester Primary School</a></strong> URN 101573</h2>
-              <p class="govuk-!-margin-top-3">
-              Route: Form a MAT</br>
-              Application to join a trust: Gloucestershire Academy Trust</br>
-              Local authority: Gloucestershire</br>
-              Delivery officer: <span class="empty">Empty</span>
-              </p>
-            </td>
-            <td class="govuk-table__cell govuk-table__cell prepare-text-align-right">
-              <p class="govuk-!-margin-top-0">
-                <strong class="govuk-tag govuk-tag--yellow">Pre Advisory Board</strong>
-              </p>
-              <p class="govuk-hint  govuk-!-margin-top-0">
-                Project created date: 8 February 2023</br>
-                Advisory Board date: <span class="empty">Empty</span></br>
-                Opening date: <span class="empty">Empty</span>
-              </p>
-            </td>   
-          </tr>
+      <h2 class="govuk-heading-l">Preview or generate project template</h2>
+      <p>Preview your template before you generate it into a Word document. Or, you can generate the document without previewing it.</p>
 
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell"><h2 class="govuk-caption-l govuk-!-margin-bottom-0 govuk-!-margin-top-1"><strong><a href="task_list_stroud.html">Stroud Primary School</a></strong> URN 102821</h2>
-              <p class="govuk-!-margin-top-3">
-              Route: Form a MAT</br>
-              Application to join a trust: Gloucestershire Academy Trust</br>
-              Local authority: Gloucestershire</br>
-              Delivery officer: <span class="empty">Empty</span>
-              </p>
-            </td>
-            <td class="govuk-table__cell govuk-table__cell prepare-text-align-right">
-              <p class="govuk-!-margin-top-0">
-                <strong class="govuk-tag govuk-tag--yellow">Pre Advisory Board</strong>
-              </p>
-              <p class="govuk-hint  govuk-!-margin-top-0">
-                Project created date: 8 February 2023</br>
-                Advisory Board date: <span class="empty">Empty</span></br>
-                Opening date: <span class="empty">Empty</span>
-              </p>
-            </td>   
-          </tr>
-
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell"><h2 class="govuk-caption-l govuk-!-margin-bottom-0 govuk-!-margin-top-1"><strong><a href="#">Prestbury Primary School</a></strong> URN 103459</h2>
-              <p class="govuk-!-margin-top-3">
-              Route: Form a MAT</br>
-              Application to join a trust: Gloucestershire Academy Trust</br>
-              Local authority: Gloucestershire</br>
-              Delivery officer: <span class="empty">Empty</span>
-              </p>
-            </td>
-            <td class="govuk-table__cell govuk-table__cell prepare-text-align-right">
-              <p class="govuk-!-margin-top-0">
-                <strong class="govuk-tag govuk-tag--yellow">Pre Advisory Board</strong>
-              </p>
-              <p class="govuk-hint  govuk-!-margin-top-0">
-                Project created date: 8 February 2023</br>
-                Advisory Board date: <span class="empty">Empty</span></br>
-                Opening date: <span class="empty">Empty</span>
-              </p>
-            </td>   
-          </tr>
-
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell"><h2 class="govuk-caption-l govuk-!-margin-bottom-0 govuk-!-margin-top-1"><strong><a href="#">Winchcombe Primary School</a></strong> URN 104944</h2>
-              <p class="govuk-!-margin-top-3">
-              Route: Form a MAT</br>
-              Application to join a trust: Gloucestershire Academy Trust</br>
-              Local authority: Gloucestershire</br>
-              Delivery officer: <span class="empty">Empty</span>
-              </p>
-            </td>
-            <td class="govuk-table__cell govuk-table__cell prepare-text-align-right">
-              <p class="govuk-!-margin-top-0">
-                <strong class="govuk-tag govuk-tag--yellow">Pre Advisory Board</strong>
-              </p>
-              <p class="govuk-hint  govuk-!-margin-top-0">
-                Project created date: 8 February 2023</br>
-                Advisory Board date: <span class="empty">Empty</span></br>
-                Opening date: <span class="empty">Empty</span>
-              </p>
-            </td>   
-          </tr>
-        </tbody>
-        </table>
+      <div class="govuk-button-group">
+        <a href="generate/generate_summary_involuntary.html" role="button" draggable="false" data-module="govuk-button" class="govuk-button">
+          Preview project template
+        </a>
+        <a href="generate/generate_documents_involuntary" role="button" draggable="false" class="govuk-button govuk-button--secondary">
+          Generate project template
+        </a>
+      </div>
+    </ul>
   </div>
 </div>
 {% endblock %}

--- a/app/views/sprint-49/generate/generate_summary_involuntary.html
+++ b/app/views/sprint-49/generate/generate_summary_involuntary.html
@@ -83,25 +83,7 @@
       <dd class="govuk-summary-list__actions"></dd>
   </div>
 
-  <!--
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key govuk-!-width-two-thirds"><a name="recommendation"></a>
-          Recommendation
-        </dt>
-        <dd class="govuk-summary-list__value">
-          {% if data['recomendation']%}
-                {{data['recomendation']}}
-               {% else %} 
-               <span class="empty">Empty</span>
-              {% endif %}
-        </dd>
-          <dd class="govuk-summary-list__actions">
-            
-              <a class="govuk-link" href="../overview/recommendation?returnToSummary=yes">
-                Change<span class="govuk-visually-hidden">recommendation</span>
-                </a>
-          </dd>
-      </div>
+
     
 
       <div class="govuk-summary-list__row">
@@ -116,12 +98,12 @@
               {% endif %}
         </dd>
           <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="../overview/aorequired?returnToSummary=yes">
+              <a class="govuk-link" href="../overview/aorequired-involuntary?returnToSummary=yes">
                 Change<span class="govuk-visually-hidden">academy order required</span>
                 </a>
               </dd>
       </div>
-    -->
+
 
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key"><a name="routes"></a>
@@ -129,7 +111,7 @@
         </dt>
         <dd class="govuk-summary-list__value">Sponsor, grant only £25000</dd>
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="../overview/route?returnToSummary=yes">
+            <a class="govuk-link" href="../overview/route-involuntary?returnToSummary=yes">
               Change<span class="govuk-visually-hidden">route and grant</span>
             </a>
           </dd>   
@@ -183,7 +165,7 @@
               {% endif %}
         </dd>
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="../overview/set-htb?returnToSummary=yes">
+            <a class="govuk-link" href="../overview/set-htb-involuntary?returnToSummary=yes">
                 Change<span class="govuk-visually-hidden">headteacher board date</span>
                 </a>
           </dd>
@@ -197,7 +179,7 @@
          {{ data['opening-date']}} 
         </dd>
         <dd class="govuk-summary-list__actions">
-          <a class="govuk-link" href="../overview/opening?returnToSummary=yes">
+          <a class="govuk-link" href="../overview/opening-involuntary?returnToSummary=yes">
             Change<span class="govuk-visually-hidden">proposed academy opening date</span>
           </a>
         </dd>
@@ -224,7 +206,7 @@
         {% endif %}
         </dd>
         <dd class="govuk-summary-list__actions">
-          <a class="govuk-link" href="../overview/previous-htb?returnToSummary=yes">
+          <a class="govuk-link" href="../overview/previous-htb-involuntary?returnToSummary=yes">
             Change<span class="govuk-visually-hidden">headteacher board date</span>
             </a>
         </dd>
@@ -265,7 +247,7 @@
          <span class="empty">Empty</span>
         {% endif %}
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="../overview/author?returnToSummary=yes">
+            <a class="govuk-link" href="../overview/author-involuntary?returnToSummary=yes">
               Change<span class="govuk-visually-hidden">recommendation</span>
               </a>
           </dd>
@@ -283,7 +265,7 @@
       {% endif %}
       </dd>
       <dd class="govuk-summary-list__actions">
-        <a class="govuk-link" href="../overview/cleared.html?returnToSummary=yes">
+        <a class="govuk-link" href="../overview/cleared-involuntary.html?returnToSummary=yes">
           Change<span class="govuk-visually-hidden">cleared by</span>
         </a>
       </dd>
@@ -354,7 +336,7 @@
           Published admission number (PAN)
         </dt>
         <dd class="govuk-summary-list__value">210</dd>
-        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="../general-info/PAN?returnToSummary=yes">Change<span class="govuk-visually-hidden">published admission numbers</span></a></dd>
+        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="../general-info/PAN-involuntary?returnToSummary=yes">Change<span class="govuk-visually-hidden">published admission numbers</span></a></dd>
       </div>
 
       <div class="govuk-summary-list__row">
@@ -394,7 +376,7 @@
          {% else %} 
          <span class="empty">Empty</span>
         {% endif %}
-          <dd class="govuk-summary-list__actions"><a class="govuk-link" href="../general-info/viability?returnToSummary=yes">Change<span class="govuk-visually-hidden">viability issues</span></a></dd>
+          <dd class="govuk-summary-list__actions"><a class="govuk-link" href="../general-info/viability-involuntary?returnToSummary=yes">Change<span class="govuk-visually-hidden">viability issues</span></a></dd>
       </div>
 
       <div class="govuk-summary-list__row">
@@ -406,7 +388,7 @@
          {% else %} 
          <span class="empty">Empty</span>
         {% endif %}
-          <dd class="govuk-summary-list__actions"><a class="govuk-link" href="../general-info/deficit?returnToSummary=yes">Change<span class="govuk-visually-hidden">financial surplus or deficit</span></a> </dd>
+          <dd class="govuk-summary-list__actions"><a class="govuk-link" href="../general-info/deficit-involuntary?returnToSummary=yes">Change<span class="govuk-visually-hidden">financial surplus or deficit</span></a> </dd>
       </div>
 
       <div class="govuk-summary-list__row">
@@ -444,7 +426,7 @@
         {% endif %}<br>
         {{data['distance-more-detail']}}
         <dd class="govuk-summary-list__actions">
-          <a class="govuk-link" href="../general-info/distance?returnToSummary=yes">
+          <a class="govuk-link" href="../general-info/distance-involuntary?returnToSummary=yes">
             Change<span class="govuk-visually-hidden">distance to trust headquarters</span>
           </a>
         </dd>
@@ -466,7 +448,7 @@
           {% else %} 
           <span class="empty">Empty</span>
         {% endif %}
-        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="../general-info/local-mp?returnToSummary=yes">
+        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="../general-info/local-mp-involuntary?returnToSummary=yes">
           Change<span class="govuk-visually-hidden">MP name</span>
         </a></dd>
       </div>
@@ -480,7 +462,7 @@
          {% else %} 
          <span class="empty">Empty</span>
        {% endif %}
-        <dd class="govuk-summary-list__actions"> <a class="govuk-link" href="../general-info/local-mp?returnToSummary=yes">
+        <dd class="govuk-summary-list__actions"> <a class="govuk-link" href="../general-info/local-mp-involuntary?returnToSummary=yes">
           Change<span class="govuk-visually-hidden">MP political party</span>
         </a></dd>
       </div>
@@ -601,7 +583,7 @@
 <dl>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
-   Additional information<a name="ofsted"></a>
+   Additional informationftjutry<a name="ofsted"></a>
       </dt>
       <dd class="govuk-summary-list__value govuk-!-width-two-thirds">
         {% if data['ofsted-more-detail']%}
@@ -610,7 +592,7 @@
        <span class="empty">Empty</span>
       {% endif %}
       </dd>
-      <dd class="govuk-summary-list__actions"><a class="govuk-link" href="../school-performance/ofsted-information?returnToSummary=yes">  Change<span class="govuk-visually-hidden">Ofsted additional information</span></a></dd>
+      <dd class="govuk-summary-list__actions"><a class="govuk-link" href="../school-performance/ofsted-information-involuntary?returnToSummary=yes">  Change<span class="govuk-visually-hidden">Ofsted additional information</span></a></dd>
     </div>
   </dl>
   </div>
@@ -645,7 +627,7 @@
               <span class="empty">Empty</span>
               {% endif %}</dd>
             <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="../rationale/project-rationale?returnToSummary=yes">
+              <a class="govuk-link" href="../rationale/sponsor-rationale-involuntary?returnToSummary=yes">
                 Change<span class="govuk-visually-hidden">project rationale</span>
               </a>
             </dd>
@@ -685,7 +667,7 @@
           {% endif %}
         </dd>
 
-        <dd class="govuk-summary-list__actions">    <a class="govuk-link" href="../risks-and-issues/risks-and-issues?returnToSummary=yes">  Change<span class="govuk-visually-hidden">risks and issues</span>
+        <dd class="govuk-summary-list__actions">    <a class="govuk-link" href="../risks-and-issues/risks-and-issues-involuntary?returnToSummary=yes">  Change<span class="govuk-visually-hidden">risks and issues</span>
         </a>  
         </dd>
       </div>
@@ -806,7 +788,7 @@
     <a name="revenue"></a>
   <h3 class="govuk-!-margin-bottom-2">Remaining revenue on 31 March</h3>
 </dt>
-<dd class="govuk-summary-list__actions"><a class="govuk-link" href="../school-budget/revenue?returnToSummary=yes">
+<dd class="govuk-summary-list__actions"><a class="govuk-link" href="../school-budget/revenue-involuntary?returnToSummary=yes">
   Change remaining revenue<span class="govuk-visually-hidden">Change data in remaining revenue section</span>
 </a>
 </dd>
@@ -865,7 +847,7 @@ If the school has a deficit, explain why
     <a name="capital"></a>
   <h3 class="govuk-!-margin-bottom-2">Remaining capital on 31 March</h3>
 </dt>
-<dd class="govuk-summary-list__actions"><a class="govuk-link" href="../school-budget/capital?returnToSummary=yes">
+<dd class="govuk-summary-list__actions"><a class="govuk-link" href="../school-budget/capital-involuntary?returnToSummary=yes">
   Change remaining capital<span class="govuk-visually-hidden">Change data in remaining capital section</span>
 </a>
 </dd>
@@ -921,7 +903,7 @@ If the school has a deficit, explain why
     <a name="loans-leases"></a>
   <h3 class="govuk-!-margin-bottom-2">Loans and financial leases</h3>
 </dt>
-<dd class="govuk-summary-list__actions"><a class="govuk-link" href="../school-budget/loans-leases?returnToSummary=yes">
+<dd class="govuk-summary-list__actions"><a class="govuk-link" href="../school-budget/loans-leases-involuntary?returnToSummary=yes">
   Change loans and leases<span class="govuk-visually-hidden">Change data in loans and leases section</span>
 </a>
 </dd>
@@ -994,7 +976,7 @@ Purpose of the leases
      <span class="empty">Empty</span>
     {% endif %}
     </dd>
-    <dd class="govuk-summary-list__actions govuk-!-width-one-third"><a class="govuk-link" href="../school-budget/budget-information-comments#additional_info?returnToSummary=yes">  Change<span class="govuk-visually-hidden">pupil forecasts additional information</span></a></dd>
+    <dd class="govuk-summary-list__actions govuk-!-width-one-third"><a class="govuk-link" href="../school-budget/budget-information-comments-involuntary#additional_info?returnToSummary=yes">  Change<span class="govuk-visually-hidden">pupil forecasts additional information</span></a></dd>
   </div>
 
 </section>  
@@ -1057,7 +1039,7 @@ Additional information
    <span class="empty">Empty</span>
   {% endif %}
   </dd>
-  <dd class="govuk-summary-list__actions"><a class="govuk-link" href="../pupil-forecasts/school-pupil-forecasts?returnToSummary=yes">  Change<span class="govuk-visually-hidden">pupil forecasts additional information</span></a></dd>
+  <dd class="govuk-summary-list__actions"><a class="govuk-link" href="../pupil-forecasts/school-pupil-forecasts-involuntary?returnToSummary=yes">  Change<span class="govuk-visually-hidden">pupil forecasts additional information</span></a></dd>
 </div>
 </dl>
 
@@ -1552,7 +1534,7 @@ Additional information
            <span class="empty">Empty</span>
           {% endif %}
           </dd>
-          <dd class="govuk-summary-list__actions"><a class="govuk-link" href="../key-stage/key-stage-performance-tables?returnToSummary=yes">  Change<span class="govuk-visually-hidden">key stage performance additional information</span></a></dd>
+          <dd class="govuk-summary-list__actions"><a class="govuk-link" href="../key-stage/key-stage-performance-tables-involuntary?returnToSummary=yes">  Change<span class="govuk-visually-hidden">key stage performance additional information</span></a></dd>
         </div>
         </dl>
         
@@ -2857,7 +2839,7 @@ Additional information
              <span class="empty">Empty</span>
             {% endif %}
             </dd>
-            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="../key-stage/key-stage-4-performance-tables?returnToSummary=yes">Change<span class="govuk-visually-hidden">key stage performance additional information</span></a></dd>
+            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="../key-stage/key-stage-4-performance-tables-involuntary?returnToSummary=yes">Change<span class="govuk-visually-hidden">key stage performance additional information</span></a></dd>
           </div>
           </dl>
           
@@ -3158,7 +3140,7 @@ Additional information
              <span class="empty">Empty</span>
             {% endif %}
             </dd>
-            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="../key-stage/key-stage-5-performance-tables?returnToSummary=yes">Change<span class="govuk-visually-hidden">key stage performance additional information</span></a></dd>
+            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="../key-stage/key-stage-5-performance-tables-involuntary?returnToSummary=yes">Change<span class="govuk-visually-hidden">key stage performance additional information</span></a></dd>
           </div>
           </dl>
           

--- a/app/views/sprint-49/key-stage/key-stage-4-performance-tables-involuntary.html
+++ b/app/views/sprint-49/key-stage/key-stage-4-performance-tables-involuntary.html
@@ -1,0 +1,1325 @@
+{% extends "layout.html" %}
+
+{% block beforeContent %}
+  
+<a href="javascript:history.back();" class="govuk-back-link">Back</a>
+{% endblock %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+  
+{% block content %}
+ 
+      {% if data['returnToSummary'] == 'yes' %}
+      <form action="../generate/generate_summary#performance4" method="post">
+        {% else %}
+        <form action="key-stage-4-performance-comments#additional_info" method="post">
+      {% endif %}
+      <input hidden type="text" name="returnToSummary" value="no"/>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l">Cheltenham Spa Primary School</span>
+  <h1 class="govuk-heading-l">Key stage 4 performance tables</h1> 
+  <p class="govuk-body">This information comes from TRAMS and you can <a href="#additional_info">add additional information</a> if you need to. These performance tables and additional information will go into your project template.</p>
+  
+  <p class="govuk-body-s">TRAMS last updated on: 23 March 2021<br>
+    <a href="https://www.compare-school-performance.service.gov.uk/school/<URN>" class="govuk-link" rel="noreferrer noopener" target="_blank">Source of data: Find and compare school performance (opens in new tab)</a>
+  </p><br>
+
+  </div></div>
+
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full govuk-!-margin-bottom-3">
+        <h2 class="govuk-heading-l">
+            Attainment 8
+        </h2>
+    </div>
+      <div class="govuk-grid-column-full govuk-!-margin-bottom-6">
+
+        <table class="govuk-table govuk-!-margin-bottom-9">
+
+<caption class="govuk-table__caption govuk-table__caption--m">Attainment 8 scores</caption>
+
+
+<thead class="govuk-table__head">
+<tr class="govuk-table__row">
+
+  <th scope="col" class="govuk-table__header"></th>
+
+  <th scope="col" class="govuk-table__header">2016</th>
+
+  <th scope="col" class="govuk-table__header">2017</th>
+
+  <th scope="col" class="govuk-table__header">2018</th>
+
+</tr>
+</thead>
+
+<tbody class="govuk-table__body">
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >St Wilfrid's Primary School</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >53.1 <br> (disadvantaged 47.6)</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >54.7 <br> (disadvantaged 49.6)</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >53.8 <br> (disadvantaged 48.6)</td>
+      
+    
+    </tr>
+  
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >Warrington LA average</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >46.2</td>
+      
+    
+    </tr>
+  
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >National average</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >46.50 <br> (disadvantaged 36.70)</td>
+      
+    
+    </tr>
+  
+
+</tbody>
+</table>
+
+
+        <table class="govuk-table govuk-!-margin-bottom-9">
+
+<caption class="govuk-table__caption govuk-table__caption--m">Attainment 8 English</caption>
+
+
+<thead class="govuk-table__head">
+<tr class="govuk-table__row">
+
+  <th scope="col" class="govuk-table__header"></th>
+
+  <th scope="col" class="govuk-table__header">2016</th>
+
+  <th scope="col" class="govuk-table__header">2017</th>
+
+  <th scope="col" class="govuk-table__header">2018</th>
+
+</tr>
+</thead>
+
+<tbody class="govuk-table__body">
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >St Wilfrid's Primary School</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >53.1 <br> (disadvantaged 47.6)</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >54.7 <br> (disadvantaged 49.6)</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >53.8 <br> (disadvantaged 48.6)</td>
+      
+    
+    </tr>
+  
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >Warrington LA average</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >9.7</td>
+      
+    
+    </tr>
+  
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >National average</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >9.90 <br> (disadvantaged 8.10)</td>
+      
+    
+    </tr>
+  
+
+</tbody>
+</table>
+
+
+        <table class="govuk-table govuk-!-margin-bottom-9">
+
+<caption class="govuk-table__caption govuk-table__caption--m">Attainment 8 Maths</caption>
+
+
+<thead class="govuk-table__head">
+<tr class="govuk-table__row">
+
+  <th scope="col" class="govuk-table__header"></th>
+
+  <th scope="col" class="govuk-table__header">2016</th>
+
+  <th scope="col" class="govuk-table__header">2017</th>
+
+  <th scope="col" class="govuk-table__header">2018</th>
+
+</tr>
+</thead>
+
+<tbody class="govuk-table__body">
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >St Wilfrid's Primary School</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >53.1 <br> (disadvantaged 47.6)</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >54.7 <br> (disadvantaged 49.6)</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >53.8 <br> (disadvantaged 48.6)</td>
+      
+    
+    </tr>
+  
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >Warrington LA average</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >8.8</td>
+      
+    
+    </tr>
+  
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >National average</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >9.00 <br> (disadvantaged 7.00)</td>
+      
+    
+    </tr>
+  
+
+</tbody>
+</table>
+
+
+        <table class="govuk-table govuk-!-margin-bottom-9">
+
+<caption class="govuk-table__caption govuk-table__caption--m">Attainment 8 EBacc</caption>
+
+
+<thead class="govuk-table__head">
+<tr class="govuk-table__row">
+
+  <th scope="col" class="govuk-table__header"></th>
+
+  <th scope="col" class="govuk-table__header">2016</th>
+
+  <th scope="col" class="govuk-table__header">2017</th>
+
+  <th scope="col" class="govuk-table__header">2018</th>
+
+</tr>
+</thead>
+
+<tbody class="govuk-table__body">
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >St Wilfrid's Primary School</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >53.1 <br> (disadvantaged 47.6)</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >54.7 <br> (disadvantaged 49.6)</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >53.8 <br> (disadvantaged 48.6)</td>
+      
+    
+    </tr>
+  
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >Warrington LA average</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >13</td>
+      
+    
+    </tr>
+  
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >National average</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >13.40 <br> (disadvantaged 10.10)</td>
+      
+    
+    </tr>
+  
+
+</tbody>
+</table>
+
+    </div>
+
+    <div class="govuk-grid-column-full govuk-!-margin-bottom-6">
+
+        <h2 class="govuk-heading-l">
+            Progress 8
+        </h2>
+
+        <table class="govuk-table govuk-!-margin-bottom-9">
+
+<caption class="govuk-table__caption govuk-table__caption--m">Pupils included in P8</caption>
+
+
+<thead class="govuk-table__head">
+<tr class="govuk-table__row">
+
+  <th scope="col" class="govuk-table__header"></th>
+
+  <th scope="col" class="govuk-table__header">2016</th>
+
+  <th scope="col" class="govuk-table__header">2017</th>
+
+  <th scope="col" class="govuk-table__header">2018</th>
+
+</tr>
+</thead>
+
+<tbody class="govuk-table__body">
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >St Wilfrid's Primary School</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >191 <br> (disadvantaged 54)</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >182 <br> (disadvantaged 43)</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >219 <br> (disadvantaged 48)</td>
+      
+    
+    </tr>
+  
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >Warrington LA average</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >1,851</td>
+      
+    
+    </tr>
+  
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >National average</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >49,4832</td>
+      
+    
+    </tr>
+  
+
+</tbody>
+</table>
+
+
+        <table class="govuk-table govuk-!-margin-bottom-9">
+
+<caption class="govuk-table__caption govuk-table__caption--m">School progress scores</caption>
+
+
+<thead class="govuk-table__head">
+<tr class="govuk-table__row">
+
+  <th scope="col" class="govuk-table__header"></th>
+
+  <th scope="col" class="govuk-table__header">2016</th>
+
+  <th scope="col" class="govuk-table__header">2017</th>
+
+  <th scope="col" class="govuk-table__header">2018</th>
+
+</tr>
+</thead>
+
+<tbody class="govuk-table__body">
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >St Wilfrid's Primary School</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >0.23 <br> (disadvantaged 0.02)</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >0.62 <br> (disadvantaged 0.55)</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >0.34 <br> (disadvantaged 0.25)</td>
+      
+    
+    </tr>
+  
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >School confidence interval</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >0.08	to 0.38</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >0.44	to 0.8</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >0.17	to 0.5</td>
+      
+    
+    </tr>
+  
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >Warrington LA average</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >1,851</td>
+      
+    
+    </tr>
+  
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >Warrington LA confidence interval</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >-0.3	to -0.19</td>
+      
+    
+    </tr>
+  
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >National average</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >49,4832</td>
+      
+    
+    </tr>
+  
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >National average confidence interval</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >0.00</td>
+      
+    
+    </tr>
+  
+
+</tbody>
+</table>
+
+
+        <table class="govuk-table govuk-!-margin-bottom-9">
+
+<caption class="govuk-table__caption govuk-table__caption--m">Progress 8 English</caption>
+
+
+<thead class="govuk-table__head">
+<tr class="govuk-table__row">
+
+  <th scope="col" class="govuk-table__header"></th>
+
+  <th scope="col" class="govuk-table__header">2016</th>
+
+  <th scope="col" class="govuk-table__header">2017</th>
+
+  <th scope="col" class="govuk-table__header">2018</th>
+
+</tr>
+</thead>
+
+<tbody class="govuk-table__body">
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >St Wilfrid's Primary School</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >0.35 <br> (disadvantaged 0.31)</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >0.5 <br> (disadvantaged 0.62)</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >0.15 <br> (disadvantaged 0.11)</td>
+      
+    
+    </tr>
+  
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >Warrington LA average</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >-0.33</td>
+      
+    
+    </tr>
+  
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >National average</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >-0.04 <br> (disadvantaged -0.44)</td>
+      
+    
+    </tr>
+  
+
+</tbody>
+</table>
+
+
+        <table class="govuk-table govuk-!-margin-bottom-9">
+
+<caption class="govuk-table__caption govuk-table__caption--m">Progress 8 Maths</caption>
+
+
+<thead class="govuk-table__head">
+<tr class="govuk-table__row">
+
+  <th scope="col" class="govuk-table__header"></th>
+
+  <th scope="col" class="govuk-table__header">2016</th>
+
+  <th scope="col" class="govuk-table__header">2017</th>
+
+  <th scope="col" class="govuk-table__header">2018</th>
+
+</tr>
+</thead>
+
+<tbody class="govuk-table__body">
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >St Wilfrid's Primary School</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >0.26 <br> (disadvantaged 0.16)</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >0.6 <br> (disadvantaged 0.44)</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >0.37 <br> (disadvantaged 0.23)</td>
+      
+    
+    </tr>
+  
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >Warrington LA average</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >-0.32</td>
+      
+    
+    </tr>
+  
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >National average</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >-0.02 <br> (disadvantaged -0.39)</td>
+      
+    
+    </tr>
+  
+
+</tbody>
+</table>
+
+
+        <table class="govuk-table govuk-!-margin-bottom-9">
+
+<caption class="govuk-table__caption govuk-table__caption--m">Progress 8 EBacc</caption>
+
+
+<thead class="govuk-table__head">
+<tr class="govuk-table__row">
+
+  <th scope="col" class="govuk-table__header"></th>
+
+  <th scope="col" class="govuk-table__header">2016</th>
+
+  <th scope="col" class="govuk-table__header">2017</th>
+
+  <th scope="col" class="govuk-table__header">2018</th>
+
+</tr>
+</thead>
+
+<tbody class="govuk-table__body">
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >St Wilfrid's Primary School</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >0.16 <br> (disadvantaged -0.17)</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >0.57 <br> (disadvantaged 0.5)</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >0.42 <br> (disadvantaged 0.27)</td>
+      
+    
+    </tr>
+  
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >Warrington LA average</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >-0.32</td>
+      
+    
+    </tr>
+  
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >National average</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >-0.03 <br> (disadvantaged -0.49)</td>
+      
+    
+    </tr>
+  
+
+</tbody>
+</table>
+
+
+    </div>
+    
+    <div class="govuk-grid-column-full govuk-!-margin-bottom-6">
+
+        <h2 class="govuk-heading-m">
+            Percentage of students entering EBacc
+        </h2>
+
+        <table class="govuk-table govuk-!-margin-bottom-9">
+
+
+<thead class="govuk-table__head">
+<tr class="govuk-table__row">
+
+  <th scope="col" class="govuk-table__header"></th>
+
+  <th scope="col" class="govuk-table__header">2016</th>
+
+  <th scope="col" class="govuk-table__header">2017</th>
+
+  <th scope="col" class="govuk-table__header">2018</th>
+
+</tr>
+</thead>
+
+<tbody class="govuk-table__body">
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >St Wilfrid's Primary School</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >53.1 <br> (disadvantaged 47.6)</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >54.7 <br> (disadvantaged 49.6)</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >53.8 <br> (disadvantaged 48.6)</td>
+      
+    
+    </tr>
+  
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >Warrington LA average</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >46.2</td>
+      
+    
+    </tr>
+  
+
+  
+    <tr class="govuk-table__row">
+    
+      
+      
+      <th scope="row" class="govuk-table__header"
+      >National average</th>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >no data</td>
+      
+    
+      
+      
+      <td class="govuk-table__cell"
+      >46.50 <br> (disadvantaged 36.70)</td>
+      
+    
+    </tr>
+  
+
+</tbody>
+</table>
+
+
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+
+
+  {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+<a name="additional_info"></a>
+  {{ govukTextarea({
+    name: "key-stage-more-detail",
+    id: "key-stage-more-detail",
+    value: data["key-stage-more-detail"],
+    label: {
+      text: "Add any additional information if you need to",
+      classes: "govuk-label--m"
+    },
+    hint: {
+      text:"This information will go into your project template under the key stage performance tables section."
+    }
+  }) }}
+
+  {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+  {% from "govuk/components/button/macro.njk" import govukButton %}
+  {{ govukButton({
+    text: "Save and continue"
+  }) }}
+</form>
+
+</div>
+</div>
+{% endblock %}

--- a/app/views/sprint-49/key-stage/key-stage-5-performance-tables-involuntary.html
+++ b/app/views/sprint-49/key-stage/key-stage-5-performance-tables-involuntary.html
@@ -1,0 +1,367 @@
+{% extends "layout.html" %}
+
+{% block beforeContent %}
+  
+<a href="javascript:history.back();" class="govuk-back-link">Back</a>
+{% endblock %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+  
+{% block content %}
+ 
+      {% if data['returnToSummary'] == 'yes' %}
+      <form action="../generate/generate_summary#performance5" method="post">
+        {% else %}
+        <form action="key-stage-5-performance-comments#additional_info" method="post">
+      {% endif %}
+      <input hidden type="text" name="returnToSummary" value="no"/>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l">Cheltenham Spa Primary School</span>
+  <h1 class="govuk-heading-l">Key stage 5 performance tables</h1> 
+  <p class="govuk-body">This information comes from TRAMS and you can <a href="#additional_info">add additional information</a> if you need to. These performance tables and additional information will go into your project template.</p>
+  
+  <p class="govuk-body-s">TRAMS last updated on: 23 March 2021<br>
+    <a href="https://www.compare-school-performance.service.gov.uk/school/<URN>" class="govuk-link" rel="noreferrer noopener" target="_blank">Source of data: Find and compare school performance (opens in new tab)</a>
+  </p><br>
+
+  </div></div>
+  <div>
+    <h2 class="govuk-heading-m">2016 scores for academic and applied general qualifications</h2>
+    <table class="govuk-table govuk-!-margin-bottom-9">
+  
+      <caption class="govuk-table__caption govuk-table__caption--s">Local authority: Warrington</caption>
+      
+      
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+        
+          <th scope="col" class="govuk-table__header"></th>
+        
+          <th scope="col" class="govuk-table__header">Academic progress</th>
+        
+          <th scope="col" class="govuk-table__header">Academic average</th>
+        
+          <th scope="col" class="govuk-table__header">Applied general progress</th>
+        
+          <th scope="col" class="govuk-table__header">Applied general average</th>
+        
+        </tr>
+      </thead>
+      
+      <tbody class="govuk-table__body">
+        
+          
+            <tr class="govuk-table__row">
+            
+              
+              
+              <th scope="row" class="govuk-table__header"
+              >St Wilfrid's Primary School</th>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >-0.14</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >33.29</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >0.17</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >34.66</td>
+              
+            
+            </tr>
+          
+        
+          
+            <tr class="govuk-table__row">
+            
+              
+              
+              <th scope="row" class="govuk-table__header"
+              >National average</th>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >no data</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >no data</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >no data</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >-28.45</td>
+              
+         
+              
+            
+            </tr>
+          
+        
+          
+            
+          
+        
+      </tbody>
+    </table>
+
+    <h2 class="govuk-heading-m">2017 scores for academic and applied general qualifications</h2>
+    <table class="govuk-table govuk-!-margin-bottom-9">
+  
+      <caption class="govuk-table__caption govuk-table__caption--s">Local authority: Warrington</caption>
+      
+      
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+        
+          <th scope="col" class="govuk-table__header"></th>
+        
+          <th scope="col" class="govuk-table__header">Academic progress</th>
+        
+          <th scope="col" class="govuk-table__header">Academic average</th>
+        
+          <th scope="col" class="govuk-table__header">Applied general progress</th>
+        
+          <th scope="col" class="govuk-table__header">Applied general average</th>
+        
+        </tr>
+      </thead>
+      
+      <tbody class="govuk-table__body">
+        
+          
+            <tr class="govuk-table__row">
+            
+              
+              
+              <th scope="row" class="govuk-table__header"
+              >St Wilfrid's Primary School</th>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >-0.14</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >33.29</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >0.17</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >34.66</td>
+              
+            
+            </tr>
+          
+        
+          
+            <tr class="govuk-table__row">
+            
+              
+              
+              <th scope="row" class="govuk-table__header"
+              >National average</th>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >no data</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >no data</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >no data</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >-35.72</td>
+              
+         
+              
+            
+            </tr>
+ </tbody>
+    </table>
+
+    <h3 class="govuk-heading-m">2018 scores for academic and applied general qualifications</h3>
+    <table class="govuk-table govuk-!-margin-bottom-9">
+  
+      <caption class="govuk-table__caption govuk-table__caption--s">Local authority: Warrington</caption>
+      
+      
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+        
+          <th scope="col" class="govuk-table__header"></th>
+        
+          <th scope="col" class="govuk-table__header">Academic progress</th>
+        
+          <th scope="col" class="govuk-table__header">Academic average</th>
+        
+          <th scope="col" class="govuk-table__header">Applied general progress</th>
+        
+          <th scope="col" class="govuk-table__header">Applied general average</th>
+        
+        </tr>
+      </thead>
+      
+      <tbody class="govuk-table__body">
+        
+          
+            <tr class="govuk-table__row">
+            
+              
+              
+              <th scope="row" class="govuk-table__header"
+              >St Wilfrid's Primary School</th>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >-0.14</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >33.29</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >0.17</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >34.66</td>
+              
+            
+            </tr>
+          
+        
+          
+            <tr class="govuk-table__row">
+            
+              
+              
+              <th scope="row" class="govuk-table__header"
+              >National average</th>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >no data</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >no data</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >no data</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >-35.72</td>
+              
+         
+              
+            
+            </tr>
+ </tbody>
+    </table>
+    
+    
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+
+
+  {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+<a name="additional_info"></a>
+  {{ govukTextarea({
+    name: "key-stage-more-detail",
+    id: "key-stage-more-detail",
+    value: data["key-stage-more-detail"],
+    label: {
+      text: "Add any additional information if you need to",
+      classes: "govuk-label--m"
+    },
+    hint: {
+      text:"This information will go into your project template under the key stage performance tables section."
+    }
+  }) }}
+
+  {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+  {% from "govuk/components/button/macro.njk" import govukButton %}
+  {{ govukButton({
+    text: "Save and continue"
+  }) }}
+</form>
+
+</div>
+</div>
+{% endblock %}

--- a/app/views/sprint-49/key-stage/key-stage-performance-tables-involuntary.html
+++ b/app/views/sprint-49/key-stage/key-stage-performance-tables-involuntary.html
@@ -1,0 +1,526 @@
+{% extends "layout.html" %}
+
+{% block beforeContent %}
+  
+<a href="javascript:history.back();" class="govuk-back-link">Back</a>
+{% endblock %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+  
+{% block content %}
+ 
+      {% if data['returnToSummary'] == 'yes' %}
+      <form action="../generate/generate_summary#performance" method="post">
+        {% else %}
+        <form action="key-stage-performance-comments#additional_info" method="post">
+      {% endif %}
+      <input hidden type="text" name="returnToSummary" value="no"/>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l">Cheltenham Spa Primary School</span>
+  <h1 class="govuk-heading-l">Key stage 2 performance tables</h1> 
+  <p class="govuk-body">This information comes from TRAMS and you can <a href="#additional_info">add additional information</a> if you need to. These performance tables and additional information will go into your project template.</p>
+  
+  <p class="govuk-body-s">TRAMS last updated on: 23 March 2021<br>
+    <a href="https://www.compare-school-performance.service.gov.uk/school/<URN>" class="govuk-link" rel="noreferrer noopener" target="_blank">Source of data: Find and compare school performance (opens in new tab)</a>
+  </p><br>
+
+  </div></div>
+  <div>
+    <table class="govuk-table govuk-!-margin-bottom-9">
+  
+      <caption class="govuk-table__caption govuk-table__caption--m">2019 key stage 2</caption>
+      
+      
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+        
+          <th scope="col" class="govuk-table__header"></th>
+        
+          <th scope="col" class="govuk-table__header">Percentage meeting expected standard in reading, writing and maths</th>
+        
+          <th scope="col" class="govuk-table__header">Percentage achieving a higher standard in reading, writing and maths</th>
+        
+          <th scope="col" class="govuk-table__header">Reading progress scores</th>
+        
+          <th scope="col" class="govuk-table__header">Writing progress scores</th>
+        
+          <th scope="col" class="govuk-table__header">Maths progress scores</th>
+        
+        </tr>
+      </thead>
+      
+      <tbody class="govuk-table__body">
+        
+          
+            <tr class="govuk-table__row">
+            
+              
+              
+              <th scope="row" class="govuk-table__header"
+              >St Wilfrid's Primary School</th>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >Suppressed </td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >Suppressed </td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >Suppressed </td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >Suppressed </td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >Suppressed </td>
+              
+            
+            </tr>
+          
+        
+          
+            <tr class="govuk-table__row">
+            
+              
+              
+              <th scope="row" class="govuk-table__header"
+              >Warrington LA average</th>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >63</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >9</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >0.2</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >-0.8</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >-0.3</td>
+              
+            
+            </tr>
+          
+        
+          
+            <tr class="govuk-table__row">
+            
+              
+              
+              <th scope="row" class="govuk-table__header"
+              >National average</th>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >65 <br> (disadvantaged 51)</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >11 <br> (disadvantaged 5)</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >0.00</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >0.00</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >0.00</td>
+              
+            
+            </tr>
+          
+        
+      </tbody>
+    </table>
+    
+    
+                <table class="govuk-table govuk-!-margin-bottom-9">
+      
+      <caption class="govuk-table__caption govuk-table__caption--m">2018 key stage 2</caption>
+      
+      
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+        
+          <th scope="col" class="govuk-table__header"></th>
+        
+          <th scope="col" class="govuk-table__header">Percentage meeting expected standard in reading, writing and maths</th>
+        
+          <th scope="col" class="govuk-table__header">Percentage achieving a higher standard in reading, writing and maths</th>
+        
+          <th scope="col" class="govuk-table__header">Reading progress scores</th>
+        
+          <th scope="col" class="govuk-table__header">Writing progress scores</th>
+        
+          <th scope="col" class="govuk-table__header">Maths progress scores</th>
+        
+        </tr>
+      </thead>
+      
+      <tbody class="govuk-table__body">
+        
+          
+            <tr class="govuk-table__row">
+            
+              
+              
+              <th scope="row" class="govuk-table__header"
+              >St Wilfrid's Primary School</th>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >Suppressed </td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >Suppressed </td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >Suppressed </td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >Suppressed </td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >Suppressed </td>
+              
+            
+            </tr>
+          
+        
+          
+            <tr class="govuk-table__row">
+            
+              
+              
+              <th scope="row" class="govuk-table__header"
+              >Warrington LA average</th>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >61</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >10</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >0.1</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >-0.9</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >-0.5</td>
+              
+            
+            </tr>
+          
+        
+          
+            <tr class="govuk-table__row">
+            
+              
+              
+              <th scope="row" class="govuk-table__header"
+              >National average</th>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >64 <br> (disadvantaged 51)</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >10 <br> (disadvantaged 4)</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >0.00</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >0.00</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >0.00</td>
+              
+            
+            </tr>
+          
+        
+      </tbody>
+    </table>
+    
+    
+                <table class="govuk-table govuk-!-margin-bottom-9">
+      
+      <caption class="govuk-table__caption govuk-table__caption--m">2017 key stage 2</caption>
+      
+      
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+        
+          <th scope="col" class="govuk-table__header"></th>
+        
+          <th scope="col" class="govuk-table__header">Percentage meeting expected standard in reading, writing and maths</th>
+        
+          <th scope="col" class="govuk-table__header">Percentage achieving a higher standard in reading, writing and maths</th>
+        
+          <th scope="col" class="govuk-table__header">Reading progress scores</th>
+        
+          <th scope="col" class="govuk-table__header">Writing progress scores</th>
+        
+          <th scope="col" class="govuk-table__header">Maths progress scores</th>
+        
+        </tr>
+      </thead>
+      
+      <tbody class="govuk-table__body">
+        
+          
+            <tr class="govuk-table__row">
+            
+              
+              
+              <th scope="row" class="govuk-table__header"
+              >St Wilfrid's Primary School</th>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >()</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >()</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >()</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >()</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >()</td>
+              
+            
+            </tr>
+          
+        
+          
+            <tr class="govuk-table__row">
+            
+              
+              
+              <th scope="row" class="govuk-table__header"
+              >Warrington LA average</th>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >59</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >8</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >0.2</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >-1.2</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >-0.9</td>
+              
+            
+            </tr>
+          
+        
+          
+            <tr class="govuk-table__row">
+            
+              
+              
+              <th scope="row" class="govuk-table__header"
+              >National average</th>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >64 <br> (disadvantaged 51)</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >10 <br> (disadvantaged 4)</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >0.00</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >0.00</td>
+              
+            
+              
+              
+              <td class="govuk-table__cell"
+              >0.00</td>
+              
+            
+            </tr>
+          
+        
+      </tbody>
+    </table>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+
+
+  {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+<a name="additional_info"></a>
+  {{ govukTextarea({
+    name: "key-stage-more-detail",
+    id: "key-stage-more-detail",
+    value: data["key-stage-more-detail"],
+    label: {
+      text: "Add any additional information if you need to",
+      classes: "govuk-label--m"
+    },
+    hint: {
+      text:"This information will go into your project template under the key stage performance tables section."
+    }
+  }) }}
+
+  {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+  {% from "govuk/components/button/macro.njk" import govukButton %}
+  {{ govukButton({
+    text: "Save and continue"
+  }) }}
+</form>
+
+</div>
+</div>
+{% endblock %}

--- a/app/views/sprint-49/pupil-forecasts/school-pupil-forecasts-involuntary.html
+++ b/app/views/sprint-49/pupil-forecasts/school-pupil-forecasts-involuntary.html
@@ -1,0 +1,97 @@
+{% extends "layout.html" %}
+
+{% block beforeContent %}
+  
+<a href="javascript:history.back();" class="govuk-back-link">Back</a>
+{% endblock %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+  
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    {% if data['returnToSummary'] == 'yes' %}
+    <form action="../generate/generate_summary#forecasts" method="post">
+    {% else %}
+    <form action="school-pupil-forecasts-summary" method="post">
+  {% endif %}
+    
+    <input hidden type="text" name="returnToSummary" value="no"/>
+    
+    <span class="govuk-caption-l">Cheltenham Spa Primary School</span>
+    <h1 class="govuk-heading-l">School pupil forecasts</h1>
+    <p class="govuk-body">This comes from GIAS (Get Information about Schools) and the <a href="../related/application_newtab" target="_blank">school's application form (opens in a new tab)</a>. It will go into your project template.</p>
+    <p>Published on GIAS: <strong>June 2022</strong>.</p>
+  </div>
+</div>
+<div>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header govuk-!-width-one-half">Year</th>
+        <th scope="col" class="govuk-table__header govuk-table__header--numeric">Capacity</th>
+        <th scope="col" class="govuk-table__header govuk-table__header--numeric">Total pupil numbers</th>
+        <th scope="col" class="govuk-table__header govuk-table__header--numeric">Percentage full</th>
+    </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header ">2022</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">236</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">226</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">96%</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Projected pupil numbers on roll in the year the academy opens (year 1)</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric"></td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">189</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Projected pupil numbers on roll in the year the academy opens (year 2)</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric"></td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">189</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Projected pupil numbers on roll in the year the academy opens (year 3)</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric"></td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">189</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric"></td>
+    </tr>
+    </tbody>
+  </table>   
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    
+
+   <a href="#" name="additional_info"></a>   {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+    
+      {{ govukTextarea({
+        name: "pupil-more-detail",
+        id: "pupil-more-detail",
+        value: data["pupil-more-detail"],
+        label: {
+          text: "Add any additional information if you need to",
+          classes: "govuk-label--m"
+        },
+        hint: {
+          text:"This information will go into your project template under the school pupil forecasts section."
+        }
+      }) }}
+    
+      {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+      {% from "govuk/components/button/macro.njk" import govukButton %}
+      {{ govukButton({
+        text: "Save and continue"
+      }) }}
+    </form>
+    <p>
+
+    </p>
+  </div>
+</div>
+{% endblock %}

--- a/app/views/sprint-49/risks-and-issues/risks-and-issues-involuntary.html
+++ b/app/views/sprint-49/risks-and-issues/risks-and-issues-involuntary.html
@@ -1,0 +1,63 @@
+{% extends "layout.html" %}
+
+{% block beforeContent %}
+<a href="javascript:history.back();" class="govuk-back-link">Back</a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if data['returnToSummary'] == 'yes' %}
+        <form action="../generate/generate_summary#risks" method="post">
+        {% else %}
+        <form action="risks-summary1" method="post">
+      {% endif %}
+      <input hidden type="text" name="returnToSummary" value="no"/>
+      <span class="govuk-caption-l">Cheltenham Spa Primary School</span>
+      <h1 class="govuk-heading-l">Write about any risks or issues for this conversion</h1>
+
+    <!-- Not MVP  <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            Help with writing a rationale 
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          <p class="govuk-body">To write your rationale, you could include information about:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>how governance will work between the school and the trust</li>
+            <li>who will be the head of the school and how will the school be managed</li>
+            <li>if the school has any feeder links that would be important for the HTB to know about</li>
+          </ul>
+        </div>
+      </details> -->
+    
+      {%- from "govuk/components/textarea/macro.njk" import govukTextarea -%}
+
+      {{ govukTextarea({
+        id: 'risks',
+        name: 'risks',
+        maxlength: 500,
+        rows: 15,
+        value: data["risks"]
+        
+        }) 
+      }} 
+
+      {% from "govuk/components/button/macro.njk" import govukButton %}
+
+      {{ govukButton({
+        text: "Save and continue"
+      }) }}
+
+  
+    </form>
+
+  </div>  
+  
+  <!-- right hand nav -->    
+  <div class="govuk-grid-column-one-third">
+    {% include "../includes/useful_info_sidebar.html" %}
+  </div>
+</div>
+{% endblock %}

--- a/app/views/sprint-49/school-budget/budget-information-comments-involuntary.html
+++ b/app/views/sprint-49/school-budget/budget-information-comments-involuntary.html
@@ -1,0 +1,215 @@
+{% extends "layout.html" %}
+
+{% block beforeContent %}
+        
+<a href="javascript:history.back();" class="govuk-back-link">Back</a>
+{% endblock %}
+{% block content %}
+{% if data['returnToSummary'] == 'yes' %}
+<form action="../generate/generate_summary#budget_additional_info" method="post">
+{% else %}
+<form action="budget-information2" method="post">
+{% endif %}
+<input hidden type="text" name="returnToSummary" value="no"/>
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l">Cheltenham Spa Primary School</span>
+    <h1 class="govuk-heading-l">Confirm school budget information</h1>
+    <p class="govuk-body">This information comes from the <a href="../related/application_newtab" target="_application">school's application form (opens in a new tab)</a>. The table will go into your project template.</p>
+    <p>You can <a href="#additional_info">add additional information</a> if you need to, this will also go into your project template.</p>
+ <br>
+  </div>
+</div>
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key  govuk-!-width-two-thirds">
+        <h3 class="govuk-heading-m govuk-!-margin-bottom-0">Remaining revenue on 31 March</h3></dt>
+      <dd class="govuk-summary-list__actions govuk-!-width-two-thirds">
+        <a class="govuk-link" href="revenue">
+          Change remaining revenue<span class="govuk-visually-hidden"> Change data in the revenue section</span>
+        </a>
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Previous financial year
+      </dt>
+      <dd class="govuk-summary-list__value">
+        £{{ data['revenue-previous-year'] }}
+      </dd>
+   
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+      Current financial year (forecasted)
+      </dt>
+      <dd class="govuk-summary-list__value">
+        £{{ data['revenue-current-year']}}
+      </dd>
+   
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+       Next financial year (forecasted)
+      </dt>
+      <dd class="govuk-summary-list__value">
+        £{{ data ['revenue-next-year']}}
+      </dd>
+   
+    </div>
+  </dl>
+
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key  govuk-!-width-two-thirds">
+        <h3 class="govuk-heading-m govuk-!-margin-bottom-0">Remaining capital on 31 March</h3>
+      </dt>
+      <dd class="govuk-summary-list__actions govuk-!-width-two-thirds">
+        <a class="govuk-link" href="capital">
+          Change remaining capital<span class="govuk-visually-hidden"> Change data in the capital section</span>
+        </a>
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Previous financial year
+      </dt>
+      <dd class="govuk-summary-list__value">
+        £{{ data['capital-previous-year'] }}
+      </dd>
+      <dd class="govuk-summary-list__actions">
+      
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+      Current financial year (forecasted)
+      </dt>
+      <dd class="govuk-summary-list__value">
+        £{{ data['capital-current-year']}}
+      </dd>
+      <dd class="govuk-summary-list__actions">
+      
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+       Next financial year (forecasted)
+      </dt>
+      <dd class="govuk-summary-list__value">
+      <span class="deficit">£{{ data ['capital-next-year']}}</span>  
+      </dd>
+      <dd class="govuk-summary-list__actions">
+  
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+       If the school has a financial deficit, explain why?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        {% if data['reason-for-deficit'] %}
+        {{data['reason-for-deficit']}}
+    {% else %}
+        <span class="empty">Empty</span>
+    {% endif %}
+      </dd>
+      <dd class="govuk-summary-list__actions">
+  
+      </dd>
+    </div>
+  </dl>
+
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key  govuk-!-width-two-thirds">
+        <h3 class="govuk-heading-m govuk-!-margin-bottom-1">Loans and financial leases</h3>
+        <p class="govuk-body-s govuk-!-margin-bottom-0"><a href="../related/application_newtab#finances" target="_application">View full loans and financial leases information (opens in a new tab)</a></p>
+      </dt>
+      <dd class="govuk-summary-list__actions govuk-!-width-two-thirds">
+       <br><a class="govuk-link" href="loans-leases">
+          Change loans and leases<span class="govuk-visually-hidden"> Change data in the loans and leases section</span>
+        </a>
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Total loan amount
+      </dt>
+      <dd class="govuk-summary-list__value">
+        £{{ data['total-loan-amounts'] }}
+      </dd>
+
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+      Purpose of the loans
+      </dt>
+      <dd class="govuk-summary-list__value">
+        {{ data['purpose-of-loans']}}
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+     Total annual lease repayment amount
+      </dt>
+      <dd class="govuk-summary-list__value">
+        £{{ data ['total-lease-repayments']}}
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+   Pupose of the leases
+      </dt>
+      <dd class="govuk-summary-list__value">
+        {{ data ['purpose-of-leases']}}
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+   Have ESFA approved the loans and leases?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        {% if data['esfa-approved'] %}
+        {{data['esfa-approved']}}
+    {% else %}
+        <span class="empty">Empty</span>
+    {% endif %}
+</dd>
+</div>
+</dl>
+
+
+
+<div class="govuk-grid-row">
+<div class="govuk-grid-column-two-thirds">
+  <a name="additional_info"></a>
+
+    
+      {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+    
+      {{ govukTextarea({
+        name: "budget-more-detail",
+        id: "budget-more-detail",
+        value: data["budget-more-detail"],
+        label: {
+          text: "Add any additional information if you need to",
+          classes: "govuk-label--m"
+        },
+        hint: {
+          text:"This information will go into your project template under the school budget section."
+        }
+      }) }}
+    
+      {{ govukButton({
+        text: "Confirm and continue"
+      }) }}
+    </form>
+
+  </div>
+  </div>
+
+
+  {% endblock %}

--- a/app/views/sprint-49/school-budget/capital-involuntary.html
+++ b/app/views/sprint-49/school-budget/capital-involuntary.html
@@ -12,13 +12,13 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% if data['returnToSummary'] == 'yes' %}
-        <form action="../generate/generate_summary#revenue" method="post">
-        {% else %}  
+        <form action="../generate/generate_summary#capital" method="post">
+        {% else %}
         <form action="../school-budget/budget-information2" method="post">
       {% endif %}
       <input hidden type="text" name="returnToSummary" value="no"/>
-      <span class="govuk-caption-l">St. Wilfrid's Primary School</span>
-  <h1 class="govuk-heading-l">Update the school's remaining revenue</h1>
+      <span class="govuk-caption-l">Cheltenham Spa Primary School</span>
+  <h1 class="govuk-heading-l">Update the school's remaining capital</h1>
 <!-- Not MVP
   <details class="govuk-details" data-module="govuk-details">
     <summary class="govuk-details__summary">
@@ -31,7 +31,7 @@
     </div>
   </details>
   -->
-  <h2 class="govuk-heading-m">Remaining revenue on 31 March </h2>
+  <h2 class="govuk-heading-m">Remaining capital on 31 March </h2>
 
   {% from "govuk/components/input/macro.njk" import govukInput %}
 
@@ -41,9 +41,9 @@
       classes: "govuk-label--s"
     },
     classes: "govuk-input--width-10",
-    id: "revenue-previous-year",
-    name: "revenue-previous-year",
-    value: data["revenue-previous-year"],
+    id: "capital-previous-year",
+    name: "capital-previous-year",
+    value: data["capital-previous-year"],
     prefix: {text:"£"}
   }) }}
 
@@ -53,9 +53,9 @@
       classes: "govuk-label--s"
     },
     classes: "govuk-input--width-10",
-    id: "revenue-current-year",
-    name: "revenue-current-year",
-    value: data["revenue-current-year"],
+    id: "capital-current-year",
+    name: "capital-current-year",
+    value: data["capital-current-year"],
     prefix: {text:"£"}
   }) }}
 
@@ -65,15 +65,16 @@
       classes: "govuk-label--s"
     },
     classes: "govuk-input--width-10",
-    id: "revenue-next-year",
-    name: "revenue-next-year",
-    value: data["revenue-next-year"],
+    id: "capital-next-year",
+    name: "capital-next-year",
+    value: data["capital-next-year"],
     prefix: {text:"£"}
   }) }}
+
   {{ govukTextarea({
-    name: "revenue-reason-for-deficit",
-    id: "rrevenue-eason-for-deficit",
-    value: data["revenue-reason-for-deficit"],
+    name: "reason-for-deficit",
+    id: "reason-for-deficit",
+    value: data["reason-for-deficit"],
     label: {
       text: "If the school has a financial deficit, explain why",
       classes: "govuk-label--s"
@@ -83,7 +84,7 @@
           {{ govukButton({
             text: "Save and continue"
           }) }}
-
+          
         </form>
    
       </div>
@@ -91,25 +92,7 @@
       
    <!-- right hand nav -->    
    <div class="govuk-grid-column-one-third">
-    <aside class="app-related-items" role="complementary">
-    <h2 class="govuk-heading-s" id="subsection-title">
-    Useful information
-    </h2>
-    <nav role="navigation" aria-labelledby="subsection-title">
-    <ul class="govuk-list govuk-!-font-size-16">
-    <li>
-    <a class="govuk-link" href="#">
-  
-    </a>
-    </li>
-    <li>
-      <p class="govuk-body-s"><a href="../related/application_newtab" target="application">School application form (opens in a new tab)</a></p>
-    </li>
-  
-    </ul>
-    </nav>
-  
-    </aside>
+    {% include "../includes/useful_info_sidebar.html" %}
   </div>
     </div>
     {% endblock %}

--- a/app/views/sprint-49/school-budget/capital.html
+++ b/app/views/sprint-49/school-budget/capital.html
@@ -91,8 +91,26 @@
       
       
    <!-- right hand nav -->    
-<div class="govuk-grid-column-one-third">
-  {% include "../includes/useful_info_sidebar.html" %}
-</div>
+   <div class="govuk-grid-column-one-third">
+    <aside class="app-related-items" role="complementary">
+    <h2 class="govuk-heading-s" id="subsection-title">
+    Useful information
+    </h2>
+    <nav role="navigation" aria-labelledby="subsection-title">
+    <ul class="govuk-list govuk-!-font-size-16">
+    <li>
+    <a class="govuk-link" href="#">
+  
+    </a>
+    </li>
+    <li>
+      <p class="govuk-body-s"><a href="../related/application_newtab" target="application">School application form (opens in a new tab)</a></p>
+    </li>
+  
+    </ul>
+    </nav>
+  
+    </aside>
+  </div>
     </div>
     {% endblock %}

--- a/app/views/sprint-49/school-budget/loans-leases-involuntary.html
+++ b/app/views/sprint-49/school-budget/loans-leases-involuntary.html
@@ -12,13 +12,13 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% if data['returnToSummary'] == 'yes' %}
-        <form action="../generate/generate_summary#revenue" method="post">
-        {% else %}  
+        <form action="../generate/generate_summary#loans-leases" method="post">
+        {% else %}
         <form action="../school-budget/budget-information2" method="post">
       {% endif %}
       <input hidden type="text" name="returnToSummary" value="no"/>
-      <span class="govuk-caption-l">St. Wilfrid's Primary School</span>
-  <h1 class="govuk-heading-l">Update the school's remaining revenue</h1>
+      <span class="govuk-caption-l">Cheltenham Spa Primary School</span>
+  <h1 class="govuk-heading-l">Update the school's loans and financial leases</h1>
 <!-- Not MVP
   <details class="govuk-details" data-module="govuk-details">
     <summary class="govuk-details__summary">
@@ -31,59 +31,87 @@
     </div>
   </details>
   -->
-  <h2 class="govuk-heading-m">Remaining revenue on 31 March </h2>
+  <h2 class="govuk-heading-m">Loans and financial leases</h2>
 
+  
   {% from "govuk/components/input/macro.njk" import govukInput %}
 
   {{ govukInput({
     label: {
-      text: "Previous financial year",
+      text: "Total loan amount",
       classes: "govuk-label--s"
     },
     classes: "govuk-input--width-10",
-    id: "revenue-previous-year",
-    name: "revenue-previous-year",
-    value: data["revenue-previous-year"],
+    id: "total-loan-amounts",
+    name: "total-loan-amounts",
+    value: data["total-loan-amounts"],
     prefix: {text:"£"}
   }) }}
 
-  {{ govukInput({
-    label: {
-      text: "Current financial year (forecasted)",
-      classes: "govuk-label--s"
-    },
-    classes: "govuk-input--width-10",
-    id: "revenue-current-year",
-    name: "revenue-current-year",
-    value: data["revenue-current-year"],
-    prefix: {text:"£"}
-  }) }}
-
-  {{ govukInput({
-    label: {
-      text: "Next financial year (forecasted)",
-      classes: "govuk-label--s"
-    },
-    classes: "govuk-input--width-10",
-    id: "revenue-next-year",
-    name: "revenue-next-year",
-    value: data["revenue-next-year"],
-    prefix: {text:"£"}
-  }) }}
   {{ govukTextarea({
-    name: "revenue-reason-for-deficit",
-    id: "rrevenue-eason-for-deficit",
-    value: data["revenue-reason-for-deficit"],
+    name: "purpose-of-loans",
+    id: "purpose-of-loans",
+    value: data["purpose-of-loans"],
     label: {
-      text: "If the school has a financial deficit, explain why",
+      text: "Purpose of the loans",
+      classes: "govuk-label--s"
+    }
+  }) }}
+
+  
+  {{ govukInput({
+    label: {
+      text: "Total annual lease repayment amount",
+      classes: "govuk-label--s"
+    },
+    classes: "govuk-input--width-10",
+    id: "total-lease-repayments",
+    name: "total-lease-repayments",
+    value: data["total-lease-repayments"],
+    prefix: {text:"£"}
+  }) }}
+
+  {{ govukTextarea({
+    name: "purpose-of-leases",
+    id: "purpose-of-leases",
+    value: data["purpose-of-leases"],
+    label: {
+      text: "Purpose of the leases",
       classes: "govuk-label--s"
     }
   }) }}
   
+
+  {% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+{{ govukRadios({
+  idPrefix: "esfa-approved",
+  name: "esfa-approved",
+  fieldset: {
+    legend: {
+      text: "Has ESFA approved that the loans and leases are affordable?",
+      isPageHeading: true,
+      classes: "govuk-fieldset__legend--s"
+    }
+  },
+  items: [
+    {
+      value: "Yes",
+      checked:  data['esfa-approved'] === "Yes",
+      text: "Yes"
+    },
+    {
+      value: "No",
+      checked:  data['esfa-approved'] === "No",
+      text: "No"
+    }
+  ]
+}) }}
+  
           {{ govukButton({
             text: "Save and continue"
           }) }}
-
+          
         </form>
    
       </div>
@@ -91,25 +119,7 @@
       
    <!-- right hand nav -->    
    <div class="govuk-grid-column-one-third">
-    <aside class="app-related-items" role="complementary">
-    <h2 class="govuk-heading-s" id="subsection-title">
-    Useful information
-    </h2>
-    <nav role="navigation" aria-labelledby="subsection-title">
-    <ul class="govuk-list govuk-!-font-size-16">
-    <li>
-    <a class="govuk-link" href="#">
-  
-    </a>
-    </li>
-    <li>
-      <p class="govuk-body-s"><a href="../related/application_newtab" target="application">School application form (opens in a new tab)</a></p>
-    </li>
-  
-    </ul>
-    </nav>
-  
-    </aside>
+    {% include "../includes/useful_info_sidebar.html" %}
   </div>
     </div>
     {% endblock %}

--- a/app/views/sprint-49/school-budget/loans-leases.html
+++ b/app/views/sprint-49/school-budget/loans-leases.html
@@ -118,8 +118,26 @@
       
       
    <!-- right hand nav -->    
-<div class="govuk-grid-column-one-third">
-  {% include "../includes/useful_info_sidebar.html" %}
-</div>
+   <div class="govuk-grid-column-one-third">
+    <aside class="app-related-items" role="complementary">
+    <h2 class="govuk-heading-s" id="subsection-title">
+    Useful information
+    </h2>
+    <nav role="navigation" aria-labelledby="subsection-title">
+    <ul class="govuk-list govuk-!-font-size-16">
+    <li>
+    <a class="govuk-link" href="#">
+  
+    </a>
+    </li>
+    <li>
+      <p class="govuk-body-s"><a href="../related/application_newtab" target="application">School application form (opens in a new tab)</a></p>
+    </li>
+  
+    </ul>
+    </nav>
+  
+    </aside>
+  </div>
     </div>
     {% endblock %}

--- a/app/views/sprint-49/school-budget/revenue-involuntary.html
+++ b/app/views/sprint-49/school-budget/revenue-involuntary.html
@@ -17,7 +17,7 @@
         <form action="../school-budget/budget-information2" method="post">
       {% endif %}
       <input hidden type="text" name="returnToSummary" value="no"/>
-      <span class="govuk-caption-l">St. Wilfrid's Primary School</span>
+      <span class="govuk-caption-l">Cheltenham Spa Primary School</span>
   <h1 class="govuk-heading-l">Update the school's remaining revenue</h1>
 <!-- Not MVP
   <details class="govuk-details" data-module="govuk-details">
@@ -91,25 +91,7 @@
       
    <!-- right hand nav -->    
    <div class="govuk-grid-column-one-third">
-    <aside class="app-related-items" role="complementary">
-    <h2 class="govuk-heading-s" id="subsection-title">
-    Useful information
-    </h2>
-    <nav role="navigation" aria-labelledby="subsection-title">
-    <ul class="govuk-list govuk-!-font-size-16">
-    <li>
-    <a class="govuk-link" href="#">
-  
-    </a>
-    </li>
-    <li>
-      <p class="govuk-body-s"><a href="../related/application_newtab" target="application">School application form (opens in a new tab)</a></p>
-    </li>
-  
-    </ul>
-    </nav>
-  
-    </aside>
+    {% include "../includes/useful_info_sidebar.html" %}
   </div>
     </div>
     {% endblock %}

--- a/app/views/sprint-49/school-performance/ofsted-information-involuntary.html
+++ b/app/views/sprint-49/school-performance/ofsted-information-involuntary.html
@@ -1,0 +1,152 @@
+
+{% extends "layout.html" %}
+
+{% block beforeContent %}
+<a href="javascript:history.back();" class="govuk-back-link">Back</a>
+{% endblock %}
+
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+  
+{% block content %}
+
+      {% if data['returnToSummary'] == 'yes' %}
+        <form action="../generate/generate_summary#ofsted" method="post">
+        {% else %}
+        <form action="ofsted-comments#additional_info" method="post">
+      {% endif %}
+      <input hidden type="text" name="returnToSummary" value="no"/>
+      <span class="govuk-caption-l">Cheltenham Spa Primary School</span>
+<h1 class="govuk-heading-l">School performance (Ofsted information)</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body ">This information comes from TRAMS. The table will go into your project template.</p> 
+    <p>You can <a href="#additional_info">add additional information</a> if you need to, this will also go into your project template.</p>
+    <p class="govuk-body-s">TRAMS last updated on: 23 March 2021</p><br>
+  </div>
+</div>
+
+<div class="govuk-grid-column-full-width">
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key govuk-!-width-two-thirds">
+          <span class="govuk-body-l">Short inspection</span>
+        </dt>
+        <dd class="govuk-summary-list__value"></dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Ofsted inspection date
+        </dt>
+        <dd class="govuk-summary-list__value">
+          1 February 2020
+        </dd>      
+      </div>
+</div>
+
+
+
+<div class="govuk-grid-column-full-width">
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key govuk-!-width-two-thirds">
+      <span class="govuk-body-l">Last full inspection <b>Good</b></span>
+    </dt>
+    <dd class="govuk-summary-list__value"></dd>
+  </div>
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key govuk-width-two-thirds">
+      Ofsted inspection date
+    </dt>
+    <dd class="govuk-summary-list__value">
+      1 February 2017
+    </dd>     
+  </div>
+  
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Effectiveness of leadership and management
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <p class="govuk-body">Good</p>
+    </dd>    
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Quality of teaching, learning and assessment
+    </dt>
+    <dd class="govuk-summary-list__value">
+      Good</p>
+    </dd> 
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Personal development, behaviour and welfare
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <p class="govuk-body">Outstanding</p>
+    </dd>
+ 
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Outcomes for pupils
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <p class="govuk-body">Good</p>
+    </dd>
+  
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+    Early years provision
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <p class="govuk-body">Good</p>
+    </dd>
+ 
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+    Ofsted report
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <p class="govuk-body"><a href="https://reports.ofsted.gov.uk/provider/21/111315" target="blank">View latest inspection report on Ofsted's website (opens in a new tab)</a></p>
+    </dd>
+ 
+  </div>
+  
+</dl>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+      <a name="additional_info"></a>
+      {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+    
+      {{ govukTextarea({
+        name: "ofsted-more-detail",
+        id: "ofsted-more-detail",
+        value: data["ofsted-more-information"],
+        label: {
+          text: "Add any additional information if you need to",
+          classes: "govuk-label--m"
+        },
+        hint: {
+          text:"This information will go into your project template under the school performance (Ofsted information) section."
+        }
+      }) }}
+    
+      {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+      {% from "govuk/components/button/macro.njk" import govukButton %}
+      {{ govukButton({
+        text: "Save and continue"
+      }) }}
+    </form>
+
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
# Context

Trust info moved from own section into application form section

Trust info moved from own section into application form section

# DevOps ticket:

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/120077

# Changes proposed in this pull request

As the trust info is part of the application form, this version includes it all in together, under the 'School application form' tab

# Checklist

- Rebased master
- Cleaned commit history
- Tested by running locally