### PR TITLE
AB#120077 Form-a-MAT info panel

### DIFF
--- a/app/views/sprint-50/form-a-mat/application-cheltenham.html
+++ b/app/views/sprint-50/form-a-mat/application-cheltenham.html
@@ -9,9 +9,30 @@
 {% endblock %}
 
 {% block content %}
+
+
+
+
           
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+
+
+    <div class="govuk-notification-banner" role="region"
+  aria-labelledby="govuk-notification-banner-title"
+  data-module="govuk-notification-banner">
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+      Important
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <p class="govuk-notification-banner__heading">
+      You cannot currently use this service to create project templates for Form a MAT applications. You should use KIM instead.
+    </p>
+  </div>
+</div>
+
     <span class="govuk-caption-xl govuk-!-margin-top-6" >URN: 100006</span>
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
       Cheltenham Spa Primary School 

--- a/app/views/sprint-50/form-a-mat/application-gloucester.html
+++ b/app/views/sprint-50/form-a-mat/application-gloucester.html
@@ -12,6 +12,22 @@
           
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+
+    <div class="govuk-notification-banner" role="region"
+    aria-labelledby="govuk-notification-banner-title"
+    data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__header">
+      <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+        Important
+      </h2>
+    </div>
+    <div class="govuk-notification-banner__content">
+      <p class="govuk-notification-banner__heading">
+        You cannot currently use this service to create project templates for Form a MAT applications. You should use KIM instead.
+      </p>
+    </div>
+  </div>
+
     <span class="govuk-caption-xl govuk-!-margin-top-6" >URN: 101573</span>
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
       Gloucester Primary School 

--- a/app/views/sprint-50/form-a-mat/application-winchcombe.html
+++ b/app/views/sprint-50/form-a-mat/application-winchcombe.html
@@ -12,6 +12,22 @@
           
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+
+    <div class="govuk-notification-banner" role="region"
+  aria-labelledby="govuk-notification-banner-title"
+  data-module="govuk-notification-banner">
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+      Important
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <p class="govuk-notification-banner__heading">
+      You cannot currently use this service to create project templates for Form a MAT applications. You should use KIM instead.
+    </p>
+  </div>
+</div>
+
     <span class="govuk-caption-xl govuk-!-margin-top-6" >URN 104944</span>
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
       Winchcombe Primary School 

--- a/app/views/sprint-50/form-a-mat/projects-other-mat-cheltenham.html
+++ b/app/views/sprint-50/form-a-mat/projects-other-mat-cheltenham.html
@@ -41,6 +41,23 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+
+    <div class="govuk-notification-banner" role="region"
+  aria-labelledby="govuk-notification-banner-title"
+  data-module="govuk-notification-banner">
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+      Important
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <p class="govuk-notification-banner__heading">
+      You cannot currently use this service to create project templates for Form a MAT applications. You should use KIM instead.
+    </p>
+  </div>
+</div>
+
+
     <span class="govuk-caption-xl govuk-!-margin-top-6" >URN: 100006</span>
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
       Cheltenham Spa Primary School 

--- a/app/views/sprint-50/form-a-mat/projects-other-mat-gloucester.html
+++ b/app/views/sprint-50/form-a-mat/projects-other-mat-gloucester.html
@@ -41,6 +41,23 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+
+    <div class="govuk-notification-banner" role="region"
+  aria-labelledby="govuk-notification-banner-title"
+  data-module="govuk-notification-banner">
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+      Important
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <p class="govuk-notification-banner__heading">
+      You cannot currently use this service to create project templates for Form a MAT applications. You should use KIM instead.
+    </p>
+  </div>
+</div>
+
+
     <span class="govuk-caption-xl govuk-!-margin-top-6" >URN: 101573</span>
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
       Gloucester Primary School 

--- a/app/views/sprint-50/form-a-mat/projects-other-mat-winchcombe.html
+++ b/app/views/sprint-50/form-a-mat/projects-other-mat-winchcombe.html
@@ -41,6 +41,22 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+
+    <div class="govuk-notification-banner" role="region"
+  aria-labelledby="govuk-notification-banner-title"
+  data-module="govuk-notification-banner">
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+      Important
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <p class="govuk-notification-banner__heading">
+      You cannot currently use this service to create project templates for Form a MAT applications. You should use KIM instead.
+    </p>
+  </div>
+</div>
+
     <span class="govuk-caption-xl govuk-!-margin-top-6" >URN 104944</span>
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
       Winchcombe Primary School 


### PR DESCRIPTION
# Context

Form a MAT pages needed an info panel to advise users they cannot generate a project template using the service yet

Form a MAT pages needed an info panel to advise users they cannot generate a project template using the service yet

# DevOps ticket:

na

# Changes proposed in this pull request

 Info panel to advise users they cannot generate a project template using the service yet added to pages

# Checklist

- Rebased master
- Cleaned commit history
- Tested by running locally