### PR TITLE
AB#123934 school pupil forecasts

### DIFF
--- a/app/views/sprint-52/pupil-forecasts/school-pupil-forecasts-involuntary.html
+++ b/app/views/sprint-52/pupil-forecasts/school-pupil-forecasts-involuntary.html
@@ -15,7 +15,7 @@
     {% if data['returnToSummary'] == 'yes' %}
     <form action="../generate/generate_summary#forecasts" method="post">
     {% else %}
-    <form action="school-pupil-forecasts-summary" method="post">
+    <form action="school-pupil-forecasts-summary-involuntary" method="post">
   {% endif %}
     
     <input hidden type="text" name="returnToSummary" value="no"/>
@@ -27,6 +27,10 @@
   </div>
 </div>
 <div>
+ 
+
+
+ 
   <table class="govuk-table">
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
@@ -34,35 +38,89 @@
         <th scope="col" class="govuk-table__header govuk-table__header--numeric">Capacity</th>
         <th scope="col" class="govuk-table__header govuk-table__header--numeric">Total pupil numbers</th>
         <th scope="col" class="govuk-table__header govuk-table__header--numeric">Percentage full</th>
+        <th scope="col" class="govuk-table__header govuk-table__header--numeric"></th>
     </tr>
     </thead>
     <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header ">2022</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric">236</td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">226</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">
+        {% if data['capacity'] %}
+        {{ data['capacity']}}
+        {% else %} 
+        <span class="empty">Empty</span>
+        {% endif %}
+      </td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">
+        {% if data['total-pupil-numbers'] %}
+        {{ data['total-pupil-numbers']}}
+        {% else %} 
+        <span class="empty">Empty</span>
+        {% endif %}
+      </td>
       <td class="govuk-table__cell govuk-table__cell--numeric">96%</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric"> 
+        <a class="govuk-link" href="update-current-pupil-data">
+        Change<span class="govuk-visually-hidden"> current pupil data</span>
+        </a>
+    </td>
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Projected pupil numbers on roll in the year the academy opens (year 1)</th>
       <td class="govuk-table__cell govuk-table__cell--numeric"></td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">189</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">
+        {% if data['projected-pupils-year-1'] %}
+        {{ data['projected-pupils-year-1']}}
+        {% else %} 
+        <span class="empty">Empty</span>
+        {% endif %}
+      </td>
       <td class="govuk-table__cell govuk-table__cell--numeric"></td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">
+        <a class="govuk-link" href="update-projected-pupil-data">
+        Change<span class="govuk-visually-hidden">projected pupil data</span>
+        </a>
+      </td>
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Projected pupil numbers on roll in the year the academy opens (year 2)</th>
       <td class="govuk-table__cell govuk-table__cell--numeric"></td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">189</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">
+        {% if data['projected-pupils-year-2'] %}
+        {{ data['projected-pupils-year-2']}}
+        {% else %} 
+        <span class="empty">Empty</span>
+        {% endif %}
+      </td>
       <td class="govuk-table__cell govuk-table__cell--numeric"></td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">
+        <a class="govuk-link" href="update-projected-pupil-data">
+        Change<span class="govuk-visually-hidden">projected pupil data</span>
+        </a>
+      </td>
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Projected pupil numbers on roll in the year the academy opens (year 3)</th>
       <td class="govuk-table__cell govuk-table__cell--numeric"></td>
-      <td class="govuk-table__cell govuk-table__cell--numeric">189</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">
+        {% if data['projected-pupils-year-3'] %}
+        {{ data['projected-pupils-year-3']}}
+        {% else %} 
+        <span class="empty">Empty</span>
+        {% endif %}
+      </td>
       <td class="govuk-table__cell govuk-table__cell--numeric"></td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">
+        <a class="govuk-link" href="update-projected-pupil-data">
+        Change<span class="govuk-visually-hidden">projected pupil data</span>
+        </a>
+      </td>
     </tr>
     </tbody>
-  </table>   
+</table> 
+
+
+
 </div>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/sprint-52/pupil-forecasts/school-pupil-forecasts-summary-involuntary.html
+++ b/app/views/sprint-52/pupil-forecasts/school-pupil-forecasts-summary-involuntary.html
@@ -10,7 +10,7 @@
     {% if data['returnToSummary'] == 'yes' %}
     <form action="../generate/generate_summary#forecasts" method="post">
       {% else %}
-      <form action="../task_list" method="post">
+      <form action="../task_list_involuntary_conversions" method="post">
     {% endif %}
       </div></div>
 
@@ -30,32 +30,83 @@
           <th scope="col" class="govuk-table__header govuk-table__header--numeric">Capacity</th>
           <th scope="col" class="govuk-table__header govuk-table__header--numeric">Total pupil numbers</th>
           <th scope="col" class="govuk-table__header govuk-table__header--numeric">Percentage full</th>
+          <th scope="col" class="govuk-table__header govuk-table__header--numeric"></th>
       </tr>
       </thead>
       <tbody class="govuk-table__body">
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header ">2022</th>
-        <td class="govuk-table__cell govuk-table__cell--numeric">236</td>
-        <td class="govuk-table__cell govuk-table__cell--numeric">226</td>
+        <td class="govuk-table__cell govuk-table__cell--numeric">
+          {% if data['capacity'] %}
+          {{ data['capacity']}}
+          {% else %} 
+          <span class="empty">Empty</span>
+          {% endif %}
+        </td>
+        <td class="govuk-table__cell govuk-table__cell--numeric">
+          {% if data['total-pupil-numbers'] %}
+          {{ data['total-pupil-numbers']}}
+          {% else %} 
+          <span class="empty">Empty</span>
+          {% endif %}
+        </td>
         <td class="govuk-table__cell govuk-table__cell--numeric">96%</td>
+        <td class="govuk-table__cell govuk-table__cell--numeric"> 
+          <a class="govuk-link" href="update-current-pupil-data">
+          Change<span class="govuk-visually-hidden"> current pupil data</span>
+          </a>
+      </td>
       </tr>
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">Projected pupil numbers on roll in the year the academy opens (year 1)</th>
         <td class="govuk-table__cell govuk-table__cell--numeric"></td>
-        <td class="govuk-table__cell govuk-table__cell--numeric">189</td>
+        <td class="govuk-table__cell govuk-table__cell--numeric">
+          {% if data['projected-pupils-year-1'] %}
+          {{ data['projected-pupils-year-1']}}
+          {% else %} 
+          <span class="empty">Empty</span>
+          {% endif %}
+        </td>
         <td class="govuk-table__cell govuk-table__cell--numeric"></td>
+        <td class="govuk-table__cell govuk-table__cell--numeric">
+          <a class="govuk-link" href="update-projected-pupil-data">
+          Change<span class="govuk-visually-hidden">projected pupil data</span>
+          </a>
+        </td>
       </tr>
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">Projected pupil numbers on roll in the year the academy opens (year 2)</th>
         <td class="govuk-table__cell govuk-table__cell--numeric"></td>
-        <td class="govuk-table__cell govuk-table__cell--numeric">189</td>
+        <td class="govuk-table__cell govuk-table__cell--numeric">
+          {% if data['projected-pupils-year-2'] %}
+          {{ data['projected-pupils-year-2']}}
+          {% else %} 
+          <span class="empty">Empty</span>
+          {% endif %}
+        </td>
         <td class="govuk-table__cell govuk-table__cell--numeric"></td>
+        <td class="govuk-table__cell govuk-table__cell--numeric">
+          <a class="govuk-link" href="update-projected-pupil-data">
+          Change<span class="govuk-visually-hidden">projected pupil data</span>
+          </a>
+        </td>
       </tr>
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">Projected pupil numbers on roll in the year the academy opens (year 3)</th>
         <td class="govuk-table__cell govuk-table__cell--numeric"></td>
-        <td class="govuk-table__cell govuk-table__cell--numeric">189</td>
+        <td class="govuk-table__cell govuk-table__cell--numeric">
+          {% if data['projected-pupils-year-3'] %}
+          {{ data['projected-pupils-year-3']}}
+          {% else %} 
+          <span class="empty">Empty</span>
+          {% endif %}
+        </td>
         <td class="govuk-table__cell govuk-table__cell--numeric"></td>
+        <td class="govuk-table__cell govuk-table__cell--numeric">
+          <a class="govuk-link" href="update-projected-pupil-data">
+          Change<span class="govuk-visually-hidden">projected pupil data</span>
+          </a>
+        </td>
       </tr>
       </tbody>
   </table>           
@@ -79,7 +130,7 @@
               {% endif %}
           </dd>
           <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="school-pupil-forecasts#additional_info">
+              <a class="govuk-link" href="school-pupil-forecasts-involuntary#additional_info">
                 Change<span class="govuk-visually-hidden">pupil forecast additional information</span>
               </a>
           </dd>

--- a/app/views/sprint-52/pupil-forecasts/update-current-pupil-data.html
+++ b/app/views/sprint-52/pupil-forecasts/update-current-pupil-data.html
@@ -1,0 +1,86 @@
+{% extends "layout.html" %}
+
+{% block beforeContent %}
+<a href="javascript:history.back();" class="govuk-back-link">Back</a>
+{% endblock %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+  
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if data['returnToSummary'] == 'yes' %}
+        <form action="../generate/generate_summary#revenue" method="post">
+        {% else %}  
+        <form action="../pupil-forecasts/school-pupil-forecasts-summary-involuntary" method="post">
+      {% endif %}
+      <input hidden type="text" name="returnToSummary" value="no"/>
+      <span class="govuk-caption-l">Cheltenham Spa Primary School</span>
+  <h1 class="govuk-heading-l">Current pupil data</h1>
+<!-- Not MVP
+  <details class="govuk-details" data-module="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+        Help with viability
+      </span>
+    </summary>
+    <div class="govuk-details__text">
+     The school should be accepting more than 85% of its capacity. You can check pupil numbers by looking at the school information in TRAMS and the <a href="/pupil-forecasts/school-pupil-forecasts">School Pupil Forecast reference section</a> in the task list.
+    </div>
+  </details>
+  -->
+  
+
+  
+  {% from "govuk/components/input/macro.njk" import govukInput %}
+
+  
+  
+
+  {{ govukInput({
+    label: {
+      text: "Capacity",
+      classes: "govuk-label--s"
+    },
+    classes: "govuk-input--width-10",
+    id: "capacity",
+    name: "capacity",
+    value: data["capacity"]
+  }) }}
+
+  {{ govukInput({
+    label: {
+      text: "Total pupil numbers",
+      classes: "govuk-label--s"
+    },
+    classes: "govuk-input--width-10",
+    id: "total-pupil-numbers",
+    name: "total-pupil-numbers",
+    value: data["total-pupil-numbers"]
+  }) }}
+
+ 
+
+
+ 
+
+
+ 
+  
+          {{ govukButton({
+            text: "Save and continue"
+          }) }}
+
+        </form>
+   
+      </div>
+      
+      
+   <!-- right hand nav -->    
+   <div class="govuk-grid-column-one-third">
+    {% include "../includes/useful_info_sidebar.html" %}
+  </div>
+    </div>
+    {% endblock %}

--- a/app/views/sprint-52/pupil-forecasts/update-projected-pupil-data.html
+++ b/app/views/sprint-52/pupil-forecasts/update-projected-pupil-data.html
@@ -1,0 +1,98 @@
+{% extends "layout.html" %}
+
+{% block beforeContent %}
+<a href="javascript:history.back();" class="govuk-back-link">Back</a>
+{% endblock %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+  
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if data['returnToSummary'] == 'yes' %}
+        <form action="../generate/generate_summary#revenue" method="post">
+        {% else %}  
+        <form action="../pupil-forecasts/school-pupil-forecasts-summary-involuntary" method="post">
+      {% endif %}
+      <input hidden type="text" name="returnToSummary" value="no"/>
+      <span class="govuk-caption-l">Cheltenham Spa Primary School</span>
+  <h1 class="govuk-heading-l">Projected pupil data</h1>
+<!-- Not MVP
+  <details class="govuk-details" data-module="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+        Help with viability
+      </span>
+    </summary>
+    <div class="govuk-details__text">
+     The school should be accepting more than 85% of its capacity. You can check pupil numbers by looking at the school information in TRAMS and the <a href="/pupil-forecasts/school-pupil-forecasts">School Pupil Forecast reference section</a> in the task list.
+    </div>
+  </details>
+  -->
+  
+
+ 
+  {% from "govuk/components/input/macro.njk" import govukInput %}
+
+
+
+  {{ govukInput({
+    label: {
+      text: "Projected pupil numbers on roll in the year the academy opens (year 1)",
+      classes: "govuk-label--s"
+    },
+    classes: "govuk-input--width-10",
+    id: "projected-pupils-year-1",
+    name: "projected-pupils-year-1",
+    value: data["projected-pupils-year-1"]
+  }) }}
+
+  {{ govukInput({
+    label: {
+      text: "Projected pupil numbers on roll in the year the academy opens (year 2)",
+      classes: "govuk-label--s"
+    },
+    classes: "govuk-input--width-10",
+    id: "projected-pupils-year-2",
+    name: "projected-pupils-year-2",
+    value: data["projected-pupils-year-2"]
+  }) }}
+
+  {{ govukInput({
+    label: {
+      text: "Projected pupil numbers on roll in the year the academy opens (year 3)",
+      classes: "govuk-label--s"
+    },
+    classes: "govuk-input--width-10",
+    id: "projected-pupils-year-3",
+    name: "projected-pupils-year-3",
+    value: data["projected-pupils-year-3"]
+  }) }}
+
+
+
+
+
+
+
+
+  
+ 
+  
+          {{ govukButton({
+            text: "Save and continue"
+          }) }}
+
+        </form>
+   
+      </div>
+      
+      
+   <!-- right hand nav -->    
+   <div class="govuk-grid-column-one-third">
+    {% include "../includes/useful_info_sidebar.html" %}
+  </div>
+    </div>
+    {% endblock %}


### PR DESCRIPTION
# Context

School pupil forecast data needs to be copied in from the Annex B form

School pupil forecast data needs to be copied in from the Annex B form

# DevOps ticket:

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/123934

# Changes proposed in this pull request

Made the school pupil forecasts data editable

# Checklist

Rebased master
Cleaned commit history
Tested by running locally