### PR TITLE
AB#123934 School pupil forecasts

### DIFF
--- a/app/views/sprint-52/pupil-forecasts/school-pupil-forecasts-involuntary.html
+++ b/app/views/sprint-52/pupil-forecasts/school-pupil-forecasts-involuntary.html
@@ -45,11 +45,7 @@
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header ">2022</th>
       <td class="govuk-table__cell govuk-table__cell--numeric">
-        {% if data['capacity'] %}
-        {{ data['capacity']}}
-        {% else %} 
-        <span class="empty">Empty</span>
-        {% endif %}
+        236 
       </td>
       <td class="govuk-table__cell govuk-table__cell--numeric">
         {% if data['total-pupil-numbers'] %}

--- a/app/views/sprint-52/pupil-forecasts/school-pupil-forecasts-summary-involuntary.html
+++ b/app/views/sprint-52/pupil-forecasts/school-pupil-forecasts-summary-involuntary.html
@@ -37,11 +37,7 @@
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header ">2022</th>
         <td class="govuk-table__cell govuk-table__cell--numeric">
-          {% if data['capacity'] %}
-          {{ data['capacity']}}
-          {% else %} 
-          <span class="empty">Empty</span>
-          {% endif %}
+          236
         </td>
         <td class="govuk-table__cell govuk-table__cell--numeric">
           {% if data['total-pupil-numbers'] %}
@@ -51,14 +47,14 @@
           {% endif %}
         </td>
         <td class="govuk-table__cell govuk-table__cell--numeric">
-          {% if data['capacity'] %}
+          {% if data['total-pupil-numbers'] %}
           CALC %
           {% else %} 
           <span class="empty">Empty</span>
           {% endif %}
         </td>
         <td class="govuk-table__cell govuk-table__cell--numeric"> 
-          <a class="govuk-link" href="update-current-pupil-data">
+          <a class="govuk-link" href="update-projected-pupil-data">
           Change<span class="govuk-visually-hidden"> current pupil data</span>
           </a>
       </td>

--- a/app/views/sprint-52/pupil-forecasts/update-projected-pupil-data.html
+++ b/app/views/sprint-52/pupil-forecasts/update-projected-pupil-data.html
@@ -18,7 +18,7 @@
       {% endif %}
       <input hidden type="text" name="returnToSummary" value="no"/>
       <span class="govuk-caption-l">Cheltenham Spa Primary School</span>
-  <h1 class="govuk-heading-l">Projected pupil data</h1>
+  <h1 class="govuk-heading-l">School pupil forecasts</h1>
 <!-- Not MVP
   <details class="govuk-details" data-module="govuk-details">
     <summary class="govuk-details__summary">
@@ -36,6 +36,17 @@
  
   {% from "govuk/components/input/macro.njk" import govukInput %}
 
+
+  {{ govukInput({
+    label: {
+      text: "Total pupil numbers",
+      classes: "govuk-label--s"
+    },
+    classes: "govuk-input--width-10",
+    id: "total-pupil-numbers",
+    name: "total-pupil-numbers",
+    value: data["total-pupil-numbers"]
+  }) }}
 
 
   {{ govukInput({


### PR DESCRIPTION
# Context

Current capacity data is pulled through from GIAS

Current capacity data is pulled through from GIAS

# DevOps ticket:

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/123934

# Changes proposed in this pull request

Current capacity field not required to be editable, updated to reflect this

# Checklist

- Rebased master
- Cleaned commit history
- Tested by running locally