### PR TITLE
AB#118358 academy type route funding

### DIFF
--- a/app/views/sprint-52/overview/route-grants-involuntary.html
+++ b/app/views/sprint-52/overview/route-grants-involuntary.html
@@ -1,0 +1,207 @@
+{% extends "layout.html" %}
+
+
+{% block beforeContent %}
+
+<a href="javascript:history.back();" class="govuk-back-link">Back</a>
+{% endblock %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+  
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if data['returnToSummary'] == 'yes' %}
+        <form action="../generate/generate_summary#routes" method="post">
+        {% else %}
+        <form action="../overview/summary1-involuntary" method="post">
+      {% endif %}
+      <input hidden type="text" name="returnToSummary" value="no"/>
+      <span class="govuk-caption-l">Cheltenham Spa Primary School</span>
+      <h1 class="govuk-heading-l">Academy type, route and conversion support grant</h1>
+<h2 class="govuk-heading-m">Academy type and route</h2>
+      <p class="govuk-body-m gov">Sponsored (cannot be changed for this private beta)</p>
+
+      <h2 class="govuk-heading-m">Grant details</h2>
+
+      <div class="govuk-inset-text">
+        The amount shown below includes the £25,000 conversion grant element.
+      </div>
+
+
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Grant type
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{data['grant-type']}}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="route-type-involuntary.html">
+              Change<span class="govuk-visually-hidden"> name</span>
+            </a>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Default grant amount
+
+            
+
+
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {% if data['phase'] == 'primary' and data['grant-type'] == 'Fast track'%}
+            £70,000
+            {% endif %}
+            {% if data['phase'] == 'primary' and data['grant-type'] == 'Intermediate'%}
+            £90,000
+            {% endif %}
+            {% if data['phase'] == 'primary' and data['grant-type'] == 'Full'%}
+            £110,000
+            {% endif %}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+           
+          </dd>
+        </div>
+      </dl>
+
+     
+
+      {% from "govuk/components/radios/macro.njk" import govukRadios %}
+      {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+        {% set noHtml %}
+        {{ govukInput({
+          hint: {
+            text: "If the school has tried to convert before and was unsuccessful, it may have already spent some of its support grant, so you can decrease the amount for this project if you need to. For example, £60,000"
+          },
+          classes: "govuk-input--width-5",
+          id: "grant-revised-amount",
+          name: "grant-revised-amount",
+          prefix: {text:"£"}, 
+          value: '',
+          label: {
+            text: "Change the grant if it needs to be less than the default amount shown above",
+            classes: "govuk-label--m",
+            value: data["grant-revided-amount"]   }
+        }) }}
+
+        {{ govukTextarea({
+          name: "grant-change-reason",
+          id: "grant-change-reason",
+          title: "Reason for change of grant amount",
+          label: {
+            text: "If you changed the amount of the grant, give a reason why",
+            classes: "govuk-label--m"
+          }
+        }) }}
+        {% endset -%}
+  
+        {{ govukRadios({
+          idPrefix: "grant-change",
+          name: "grant-change",
+          fieldset: {
+            legend: {
+              text: "Are you applying for the default grant amount shown above?",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--m"
+            }
+          },
+          items: [
+            {
+              value: "Yes",
+              checked:  data['grant-change'] === "Yes",
+              text: "Yes"
+            },
+            {
+              value: "No",
+              checked:  data['grant-change'] === "No",
+              text: "No",
+              conditional: {
+                html: noHtml
+              }
+            }
+          ]
+        }) }}
+
+
+
+
+
+        
+        {% set yesHtml %}
+        {{ govukInput({
+          id: "eig-amount",
+          name: "eig-amount",
+          prefix: {text:"£"}, 
+          classes: "govuk-!-width-one-third",
+          label: {
+            text: "Environmental Improvement Grant (EIG) amount"
+          },
+          value: data["eig-amount"]
+        }) }}
+        {% endset -%}
+        
+        
+        
+        
+        
+        {{ govukRadios({
+          name: "eig",
+          fieldset: {
+            legend: {
+              text: "Are you applying for an Environmental Improvement Grant (EIG)",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--m"
+            }
+          },
+          items: [
+            {
+              value: "Yes",
+              text: "Yes",
+              checked:  data['eig'] === "Yes",
+              conditional: {
+                html: yesHtml
+              }
+            },
+            {
+              value: "No",
+              text: "No",
+              checked:  data['eig'] === "No"
+            }
+            
+          ]
+        }) }}
+
+       
+
+
+
+
+      
+
+    {{ govukButton({
+      text: "Save and continue"
+    }) }}
+
+
+
+
+      </form>
+
+    </div>
+
+    <!-- right hand nav -->
+    <div class="govuk-grid-column-one-third">
+  
+      {% include "../includes/useful_info_sidebar.html" %}
+     
+    </div>
+  </div>
+
+
+{% endblock %}

--- a/app/views/sprint-52/overview/route-type-involuntary.html
+++ b/app/views/sprint-52/overview/route-type-involuntary.html
@@ -1,0 +1,77 @@
+{% extends "layout.html" %}
+
+
+{% block beforeContent %}
+
+<a href="javascript:history.back();" class="govuk-back-link">Back</a>
+{% endblock %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+  
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if data['returnToSummary'] == 'yes' %}
+        <form action="../generate/generate_summary#routes" method="post">
+        {% else %}
+        <form action="../overview/route-grants-involuntary?phase=primary" method="post">
+      {% endif %}
+      <input hidden type="text" name="returnToSummary" value="no"/>
+      <span class="govuk-caption-l">Cheltenham Spa Primary School</span>
+      <h1 class="govuk-heading-l">Academy type, route and conversion support grant</h1>
+
+      <p class="govuk-body-m gov">Sponsored (cannot be changed for this private beta)</p>
+
+
+      {% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+{{ govukRadios({
+  name: "grant-type",
+  idPrefix: "grant-type",
+  fieldset: {
+    legend: {
+      text: "What kind of grant is the school applying for?",
+      isPageHeading: true,
+      classes: "govuk-fieldset__legend--m"
+    }
+  },
+  items: [
+    {
+      value: "Fast track",
+      text: "Fast track",
+      checked:  data['grant-type'] === "Fast track"
+    },
+    {
+      value: "Intermediate",
+      text: "Intermediate",
+      checked:  data['grant-type'] === "Intermediate"
+    },
+    {
+      value: "Full",
+      text: "Full",
+      checked:  data['grant-type'] === "Full"
+    }
+  ]
+}) }}
+ 
+
+        {{ govukButton({
+          text: "Save and continue"
+        }) }}
+
+      </form>
+
+    </div>
+
+    <!-- right hand nav -->
+    <div class="govuk-grid-column-one-third">
+  
+      {% include "../includes/useful_info_sidebar.html" %}
+     
+    </div>
+  </div>
+
+
+{% endblock %}

--- a/app/views/sprint-52/overview/summary1-involuntary.html
+++ b/app/views/sprint-52/overview/summary1-involuntary.html
@@ -62,15 +62,80 @@
           Academy type and route
         </dt>
         <dd class="govuk-summary-list__value">
-          <p class="govuk-body">Sponsored<br>
-            £70,000 </p>
+          <p class="govuk-body">Sponsored</p>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <a class="govuk-link" href="route-involuntary.html">
-            Change<span class="govuk-visually-hidden">route"</span>
+          
+        </dd>
+      </div>
+
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Grant funding type
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <p class="govuk-body">
+          {% if data['grant-type'] %}
+          {{ data['grant-type']}}
+          {% else %} 
+          <span class="empty">Empty</span>
+          {% endif %}
+          </p>
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="route-type-involuntary.html">
+            Change<span class="govuk-visually-hidden">grant funding"</span>
           </a>
         </dd>
       </div>
+
+      {%  if(data['grant-type']) %}
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Grant funding amount
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <p class="govuk-body">
+            {% if data['phase'] == 'primary' and data['grant-type'] == 'Fast track'%}
+            £70,000
+            {% endif %}
+            {% if data['phase'] == 'primary' and data['grant-type'] == 'Intermediate'%}
+            £90,000
+            {% endif %}
+            {% if data['phase'] == 'primary' and data['grant-type'] == 'Full'%}
+            £110,000
+            {% endif %}
+          </p>
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="route-grants-involuntary.html">
+            Change<span class="govuk-visually-hidden">grant funding amount"</span>
+          </a> 
+        </dd>
+      </div>
+      {% endif %}
+
+
+      {%  if(data['eig-amount']) %}
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Environmental Improvement Grant (EIG)
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <p class="govuk-body">
+            £{{ data['eig-amount']}}</p>
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="route-type-involuntary.html">
+            Change<span class="govuk-visually-hidden">additional funding"</span>
+          </a>
+        </dd>
+      </div>
+      {% endif %}
+
+
+
 
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">


### PR DESCRIPTION
# Context

Sponsored conversions can receive different grants in addition to the standard conversion support grant

Sponsored conversions can receive different grants in addition to the standard conversion support grant

# DevOps ticket:

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/118358

# Changes proposed in this pull request

Pages added to reflect this where users can select the grant type, and also change the value if needed

# Checklist

- Rebased master
- Cleaned commit history
- Tested by running locally