### PR TITLE
AB#123934 School pupil forecasts page

### DIFF
--- a/app/views/sprint-52/pupil-forecasts/school-pupil-forecasts-involuntary.html
+++ b/app/views/sprint-52/pupil-forecasts/school-pupil-forecasts-involuntary.html
@@ -43,7 +43,7 @@
     </thead>
     <tbody class="govuk-table__body">
       <tr class="govuk-table__row">
-        <th scope="row" class="govuk-table__header ">2022</th>
+        <th scope="row" class="govuk-table__header ">Current academic year</th>
         <td class="govuk-table__cell govuk-table__cell--numeric">
           236
         </td>
@@ -58,7 +58,7 @@
       </td>
       </tr>
       <tr class="govuk-table__row">
-        <th scope="row" class="govuk-table__header">Projected pupil numbers on roll in the year the academy opens (year 1)</th>
+        <th scope="row" class="govuk-table__header">Projected pupil numbers on roll (year 1)</th>
         <td class="govuk-table__cell govuk-table__cell--numeric">
           {% if data['projected-capacity-year-1'] %}
           {{ data['projected-capacity-year-1']}}
@@ -91,7 +91,7 @@
         </td>
       </tr>
       <tr class="govuk-table__row">
-        <th scope="row" class="govuk-table__header">Projected pupil numbers on roll in the year the academy opens (year 2)</th>
+        <th scope="row" class="govuk-table__header">Projected pupil numbers on roll (year 2)</th>
         <td class="govuk-table__cell govuk-table__cell--numeric">
           {% if data['projected-capacity-year-2'] %}
           {{ data['projected-capacity-year-2']}}
@@ -121,7 +121,7 @@
         </td>
       </tr>
       <tr class="govuk-table__row">
-        <th scope="row" class="govuk-table__header">Projected pupil numbers on roll in the year the academy opens (year 3)</th>
+        <th scope="row" class="govuk-table__header">Projected pupil numbers on roll (year 3)</th>
         <td class="govuk-table__cell govuk-table__cell--numeric">
           {% if data['projected-capacity-year-3'] %}
           {{ data['projected-capacity-year-3']}}

--- a/app/views/sprint-52/pupil-forecasts/school-pupil-forecasts-summary-involuntary.html
+++ b/app/views/sprint-52/pupil-forecasts/school-pupil-forecasts-summary-involuntary.html
@@ -35,7 +35,7 @@
       </thead>
       <tbody class="govuk-table__body">
       <tr class="govuk-table__row">
-        <th scope="row" class="govuk-table__header ">2022</th>
+        <th scope="row" class="govuk-table__header ">Current academic year</th>
         <td class="govuk-table__cell govuk-table__cell--numeric">
           236
         </td>
@@ -50,7 +50,7 @@
       </td>
       </tr>
       <tr class="govuk-table__row">
-        <th scope="row" class="govuk-table__header">Projected pupil numbers on roll in the year the academy opens (year 1)</th>
+        <th scope="row" class="govuk-table__header">Projected pupil numbers on roll (year 1)</th>
         <td class="govuk-table__cell govuk-table__cell--numeric">
           {% if data['projected-capacity-year-1'] %}
           {{ data['projected-capacity-year-1']}}
@@ -83,7 +83,7 @@
         </td>
       </tr>
       <tr class="govuk-table__row">
-        <th scope="row" class="govuk-table__header">Projected pupil numbers on roll in the year the academy opens (year 2)</th>
+        <th scope="row" class="govuk-table__header">Projected pupil numbers on roll (year 2)</th>
         <td class="govuk-table__cell govuk-table__cell--numeric">
           {% if data['projected-capacity-year-2'] %}
           {{ data['projected-capacity-year-2']}}
@@ -113,7 +113,7 @@
         </td>
       </tr>
       <tr class="govuk-table__row">
-        <th scope="row" class="govuk-table__header">Projected pupil numbers on roll in the year the academy opens (year 3)</th>
+        <th scope="row" class="govuk-table__header">Projected pupil numbers on roll (year 3)</th>
         <td class="govuk-table__cell govuk-table__cell--numeric">
           {% if data['projected-capacity-year-3'] %}
           {{ data['projected-capacity-year-3']}}

--- a/app/views/sprint-52/pupil-forecasts/update-projected-pupil-data.html
+++ b/app/views/sprint-52/pupil-forecasts/update-projected-pupil-data.html
@@ -39,7 +39,7 @@
 
   {{ govukInput({
     label: {
-      text: "Projected capacity in the year the academy opens (year 1)",
+      text: "Projected capacity (year 1)",
       classes: "govuk-label--s"
     },
     classes: "govuk-input--width-10",
@@ -51,7 +51,7 @@
 
   {{ govukInput({
     label: {
-      text: "Projected pupil numbers on roll in the year the academy opens (year 1)",
+      text: "Projected pupil numbers on roll (year 1)",
       classes: "govuk-label--s"
     },
     classes: "govuk-input--width-10",
@@ -62,7 +62,7 @@
 
   {{ govukInput({
     label: {
-      text: "Projected capacity in the year the academy opens (year 2)",
+      text: "Projected capacity (year 2)",
       classes: "govuk-label--s"
     },
     classes: "govuk-input--width-10",
@@ -73,7 +73,7 @@
 
   {{ govukInput({
     label: {
-      text: "Projected pupil numbers on roll in the year the academy opens (year 2)",
+      text: "Projected pupil numbers on roll (year 2)",
       classes: "govuk-label--s"
     },
     classes: "govuk-input--width-10",
@@ -84,7 +84,7 @@
 
   {{ govukInput({
     label: {
-      text: "Projected capacity in the year the academy opens (year 3)",
+      text: "Projected capacity (year 3)",
       classes: "govuk-label--s"
     },
     classes: "govuk-input--width-10",
@@ -95,7 +95,7 @@
 
   {{ govukInput({
     label: {
-      text: "Projected pupil numbers on roll in the year the academy opens (year 3)",
+      text: "Projected pupil numbers on roll (year 3)",
       classes: "govuk-label--s"
     },
     classes: "govuk-input--width-10",


### PR DESCRIPTION
# Context

Labels amended 

Labels amended 

# DevOps ticket:

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/123934

# Changes proposed in this pull request

Removed text 'in the year the school opens' from labels for forecasted figures.

# Checklist

- Rebased master
- Cleaned commit history
- Tested by running locally