### PR TITLE
AB#118358 Academy grant funding page edits

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -25,19 +25,19 @@
     <ul class="govuk-list govuk-list--bullet govuk-body-m">
       
       <li><a href="/sprint-53/task_list_sponsor_template?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Task list - Sponsor template version</a></li>
-      <!--<li><a href="/sprint-53/general-info/summary1-involuntary?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">General info page - PFI scheme row added (conditional to PFI scheme = Yes)</a></li>
-      <li><a href="/sprint-53/school-budget/confirm-school-budget-information-involuntary?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">School budget information page updated to match live service design</a></li>
-      <li><a href="/sprint-53/pupil-forecasts/school-pupil-forecasts-summary-involuntary?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">School pupil forecasts page updated to be editable</a></li>
+      <li><a href="/sprint-53/overview/route-type-involuntary?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Grant funding type - reference to 'sponsored' removed</a></li>
+      <li><a href="/sprint-53/overview/route-grants-involuntary?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Grant details page - wording changes</a></li>
+      <!--<li><a href="/sprint-53/pupil-forecasts/school-pupil-forecasts-summary-involuntary?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">School pupil forecasts page updated to be editable</a></li>
       <li><a href="/sprint-53/overview/summary1-involuntary?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">School info page - rows added for grant info</a></li>
       -->
     </ul>
     <p class="govuk-body-m">Useful shortcuts:</p>
     <ul class="govuk-list govuk-list--bullet govuk-body-m">
-      <li><a href="/sprint-52/form-a-mat/projects-list-mat?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Form a MAT - project list view</a></li>
-      <li><a href="/sprint-52/form-a-mat/application-cheltenham?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Form a MAT - application tab</a></li>
-      <li><a href="/sprint-52/form-a-mat/projects-other-mat-cheltenham?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Form a MAT - other schools tab</a></li>
-      <li><a href="/sprint-52/projects-list-involuntary-conversions-before?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Involuntary conversions - project listing page - before view</a></li>
-      <li><a href="/sprint-52/projects-list-involuntary-conversions-after?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Involuntary conversions - project listing page - after view</a></li>
+      <li><a href="/sprint-53/form-a-mat/projects-list-mat?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Form a MAT - project list view</a></li>
+      <li><a href="/sprint-53/form-a-mat/application-cheltenham?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Form a MAT - application tab</a></li>
+      <li><a href="/sprint-53/form-a-mat/projects-other-mat-cheltenham?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Form a MAT - other schools tab</a></li>
+      <li><a href="/sprint-53/projects-list-involuntary-conversions-before?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Involuntary conversions - project listing page - before view</a></li>
+      <li><a href="/sprint-53/projects-list-involuntary-conversions-after?userName=Alex%20James&userRole=Delivery%20Officer&filter-project-title=&filter-regions=null&filter-delivery-officers=null&filter-project-status=null">Involuntary conversions - project listing page - after view</a></li>
     </ul>
 
 

--- a/app/views/sprint-53/overview/route-grants-involuntary.html
+++ b/app/views/sprint-53/overview/route-grants-involuntary.html
@@ -20,11 +20,7 @@
       {% endif %}
       <input hidden type="text" name="returnToSummary" value="no"/>
       <span class="govuk-caption-l">Cheltenham Spa Primary School</span>
-      <h1 class="govuk-heading-l">Academy type, route and conversion support grant</h1>
-<h2 class="govuk-heading-m">Academy type and route</h2>
-      <p class="govuk-body-m gov">Sponsored (cannot be changed for this private beta)</p>
-
-      <h2 class="govuk-heading-m">Grant details</h2>
+      <h1 class="govuk-heading-l">Grant details</h1>
 
       <div class="govuk-inset-text">
         The amount shown below includes the £25,000 conversion grant element.
@@ -108,7 +104,7 @@
           name: "grant-change",
           fieldset: {
             legend: {
-              text: "Are you applying for the default grant amount shown above?",
+              text: "Is the school applying for the default grant amount shown above?",
               isPageHeading: true,
               classes: "govuk-fieldset__legend--m"
             }
@@ -145,13 +141,10 @@
           name: "eig",
           fieldset: {
             legend: {
-              text: "Are you applying for an Environmental Improvement Grant (EIG)?",
+              text: "Is the school applying for an Environmental Improvement Grant (EIG)?",
               isPageHeading: true,
               classes: "govuk-fieldset__legend--m"
             }
-          },
-          hint: {
-            text: "This school may be eligible for a grant of £40,000. This is subject to need on a case-by-case basis."
           },
           items: [
             {

--- a/app/views/sprint-53/overview/route-type-involuntary.html
+++ b/app/views/sprint-53/overview/route-type-involuntary.html
@@ -20,9 +20,9 @@
       {% endif %}
       <input hidden type="text" name="returnToSummary" value="no"/>
       <span class="govuk-caption-l">Cheltenham Spa Primary School</span>
-      <h1 class="govuk-heading-l">Academy type, route and conversion support grant</h1>
+      <h1 class="govuk-heading-l">What kind of grant is the school applying for?</h1>
 
-      <p class="govuk-body-m gov">Sponsored (cannot be changed for this private beta)</p>
+     
 
 
       {% from "govuk/components/radios/macro.njk" import govukRadios %}
@@ -30,13 +30,6 @@
 {{ govukRadios({
   name: "grant-type",
   idPrefix: "grant-type",
-  fieldset: {
-    legend: {
-      text: "What kind of grant is the school applying for?",
-      isPageHeading: true,
-      classes: "govuk-fieldset__legend--m"
-    }
-  },
   items: [
     {
       value: "Fast track",


### PR DESCRIPTION
# Context

Changes to grant type and funding pages

Changes to grant type and funding pages

# DevOps ticket:

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/125310

# Changes proposed in this pull request

- Removed reference to 'sponsored'
- Amended wording to reflect it was the school applying
- Removed hint text for Environmental grant

# Checklist

- Rebased master
- Cleaned commit history
- Tested by running locally